### PR TITLE
Improve event search relevance

### DIFF
--- a/src/app/api/search/events/route.ts
+++ b/src/app/api/search/events/route.ts
@@ -15,8 +15,8 @@ type SearchEventResponse = {
   link: string;
   abstract?: true;
   deprecate?: string;
-  description: Record<string, string>;
-  deprecateDescription?: Record<string, string>;
+  description: string;
+  deprecateDescription?: string;
   javadoc?: string;
 };
 
@@ -31,6 +31,75 @@ type QueryClause = {
 const normalize = (value: string | null | undefined) =>
   (value ?? "").replace(/\s+/g, " ").trim().toLocaleLowerCase();
 
+const englishStopWords = new Set([
+  "a",
+  "an",
+  "and",
+  "at",
+  "by",
+  "for",
+  "from",
+  "in",
+  "into",
+  "is",
+  "of",
+  "on",
+  "the",
+  "to",
+  "when",
+]);
+
+const normalizeJapaneseQueryEnding = (value: string) => {
+  const suffixes = [
+    "されていたとき",
+    "されていた時",
+    "していたとき",
+    "していた時",
+    "されたとき",
+    "された時",
+    "するとき",
+    "する時",
+    "したとき",
+    "した時",
+    "である",
+    "でした",
+    "だった",
+    "されていた",
+    "していた",
+    "された",
+    "している",
+    "される",
+    "します",
+    "する",
+    "した",
+    "です",
+    "だ",
+  ];
+  for (const suffix of suffixes) {
+    if (value.endsWith(suffix) && value.length > suffix.length + 1) {
+      return value.slice(0, -suffix.length);
+    }
+  }
+  return value;
+};
+
+const normalizeQueryTerm = (value: string) => {
+  const normalized = normalize(value);
+  if (englishStopWords.has(normalized)) {
+    return "";
+  }
+  if (/^[a-z]+ies$/.test(normalized)) {
+    return `${normalized.slice(0, -3)}y`;
+  }
+  if (/^[a-z]+(?:ches|shes|xes|zes|ses)$/.test(normalized)) {
+    return normalized.slice(0, -2);
+  }
+  if (/^[a-z]{4,}s$/.test(normalized)) {
+    return normalized.slice(0, -1);
+  }
+  return normalizeJapaneseQueryEnding(normalized);
+};
+
 const tokenizeQuery = (value: string) =>
   Array.from(
     value.matchAll(/"([^"]+)"|'([^']+)'|\bAND\b|\bOR\b|[^\s]+/gi),
@@ -40,6 +109,7 @@ const tokenizeQuery = (value: string) =>
 const parseQuery = (value: string): QueryClause[] => {
   const clauses: QueryClause[] = [];
   let currentTerms: QueryTerm[] = [];
+  let pendingAnd = false;
 
   for (const token of tokenizeQuery(value)) {
     const upper = token.toUpperCase();
@@ -48,18 +118,23 @@ const parseQuery = (value: string): QueryClause[] => {
         clauses.push({ terms: currentTerms });
         currentTerms = [];
       }
+      pendingAnd = false;
       continue;
     }
     if (upper === "AND") {
+      pendingAnd = currentTerms.length > 0;
       continue;
     }
-    const normalized = normalize(token);
+    const normalized = normalizeQueryTerm(token);
     if (!normalized) {
       continue;
     }
-    currentTerms.push({
-      normalized,
-    });
+    if (currentTerms.length > 0 && !pendingAnd) {
+      clauses.push({ terms: currentTerms });
+      currentTerms = [];
+    }
+    currentTerms.push({ normalized });
+    pendingAnd = false;
   }
 
   if (currentTerms.length > 0) {
@@ -119,22 +194,19 @@ const matchTermScore = (event: EventType, term: QueryTerm) => {
 };
 
 const scoreEvent = (event: EventType, clauses: QueryClause[]) => {
-  let bestScore = 0;
+  let totalScore = 0;
 
   for (const clause of clauses) {
     const termScores = clause.terms.map((term) => matchTermScore(event, term));
     if (termScores.some((score) => score === 0)) {
       continue;
     }
-    const clauseScore =
+    totalScore +=
       termScores.reduce((total, score) => total + score, 0) +
       clause.terms.length * 25;
-    if (clauseScore > bestScore) {
-      bestScore = clauseScore;
-    }
   }
 
-  return bestScore;
+  return totalScore;
 };
 
 const readEventsForVersion = async (version: string) => {
@@ -169,6 +241,12 @@ export const GET = async (request: NextRequest) => {
   const sources = splitSources(request.nextUrl.searchParams.get("source"));
   const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
   const data = await readEventsForVersion(version);
+  const lang = request.nextUrl.searchParams.get("lang") ?? "ja";
+  if (!data.lang.includes(lang)) {
+    return new NextResponse(`Unsupported lang: ${lang}`, {
+      status: 400,
+    });
+  }
 
   const matches = data.events
     .filter((event) =>
@@ -200,8 +278,8 @@ export const GET = async (request: NextRequest) => {
         link: event.link,
         abstract: event.abstract,
         deprecate: event.deprecate,
-        description: event.description,
-        deprecateDescription: event.deprecateDescription,
+        description: event.description[lang],
+        deprecateDescription: event.deprecateDescription?.[lang],
         javadoc: event.javadoc,
       }),
     );

--- a/src/components/event-list.tsx
+++ b/src/components/event-list.tsx
@@ -33,7 +33,7 @@ const EventList: FC<EventListProps> = ({
   locale,
   version,
 }) => {
-  const { events } = useEvents(locale, version);
+  const { events } = useEvents(locale, version, search, tags);
   const incompleteEvents = useMemo(
     () =>
       events?.filter(
@@ -46,13 +46,9 @@ const EventList: FC<EventListProps> = ({
   );
   const filteredEvents = useMemo(
     () =>
-      events?.filter(
-        (event) =>
-          tags.includes(event.source as EventSource) &&
-          ((event.name ?? "").match(new RegExp(search, "i")) ||
-            (event.description ?? "").match(new RegExp(search, "i"))),
-      ) ?? [],
-    [events, search, tags],
+      events?.filter((event) => tags.includes(event.source as EventSource)) ??
+      [],
+    [events, tags],
   );
   return (
     <div className="flex flex-col gap-4">

--- a/src/libs/hooks/use-events.ts
+++ b/src/libs/hooks/use-events.ts
@@ -6,19 +6,43 @@ type Event = {
   name: string;
   description: string;
   link: string;
-  abstract: string;
+  abstract?: true;
   source: EventSource;
   deprecate?: string;
   deprecateDescription?: string;
 };
 
-const useEvents = (locale: Locale, version: string) => {
+type SearchEventsResponse = {
+  events: Event[];
+};
+
+const useEvents = (
+  locale: Locale,
+  version: string,
+  search: string,
+  tags: EventSource[],
+) => {
+  const normalizedSearch = search.trim();
+  const source = tags.join(",");
   const { data: events } = useSWRImmutable(
-    version ? ["events", locale, version] : null,
-    ([, locale, version]) =>
-      fetch(
+    version ? ["events", locale, version, normalizedSearch, source] : null,
+    async ([, locale, version, search, source]) => {
+      if (search) {
+        const params = new URLSearchParams({
+          q: search,
+          version,
+          source,
+          lang: locale,
+          limit: "100",
+        });
+        const response = await fetch(`/api/search/events?${params}`);
+        const data = (await response.json()) as SearchEventsResponse;
+        return data.events;
+      }
+      return fetch(
         `/api/versions/${encodeURIComponent(version)}/events?lang=${locale}`,
-      ).then((response) => response.json() as Promise<Event[]>),
+      ).then((response) => response.json() as Promise<Event[]>);
+    },
   );
   return { events };
 };


### PR DESCRIPTION
## Summary
- Treat whitespace-separated search terms as OR clauses while preserving explicit `AND` support.
- Score search results in the API and use the API results from the event list UI.
- Add lightweight query normalization for English plural forms/stop words and Japanese sentence endings.

## Validation
- `mise exec node@24 -- ./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `mise exec node@24 -- ./node_modules/.bin/tsc -p packages/downloader/tsconfig.json --noEmit`
- `mise exec node@24 -- npm run lint`
- `mise exec node@24 -- ./node_modules/.bin/prettier --check src/app/api/search/events/route.ts src/libs/hooks/use-events.ts src/components/event-list.tsx`

Note: lint reports the existing `@next/next/no-img-element` warnings in `src/components/ko-fi-button.tsx`.