### PR TITLE
fix: Improve event search performance and usability

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,8 +13,10 @@ jobs:
           node-version-file: package.json
       - name: Install Dependencies
         run: |
-          npm install
+          npm ci
       - name: Lint
         run: npm run lint
       - name: Test
         run: npm test
+      - name: Typecheck
+        run: npm run typecheck

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,0 +1,46 @@
+# Code review: search, usability and data access
+
+Reviewed the web UI, search and version APIs, data paths, shared types, locale/theme handling, downloader/release discovery, stream downloads, service worker, build configuration and CI. Baseline: `ba746f82b9`. Existing uncommitted event-description edits were kept in the original worktree.
+
+## Changes selected
+
+- Debounce search by 300 ms, suppress incomplete IME input, and use URL search parameters as the source of truth for search, platforms and version. Native history updates avoid server-component navigations for filter changes.
+- Paginate browsing and search in 50-event pages. Report the complete matching total and let users reach results beyond the former 100-result search limit.
+- Show loading, empty selection, no-match, version-list failure and event-request failure states with recovery controls. Preserve filters when changing language.
+- Keep mobile search visible, add accessible control names/pressed states, use native buttons and disclosures, and place the promotional panel in document flow so it cannot cover event results.
+- Share version resolution/localization between APIs. Cache web data for 60 seconds with a 16-entry bound, coalesce concurrent loads, evict failed loads and reuse normalized event fields. Downloader factories default to fresh reads.
+- Align whitespace search with the documented AND behavior, preserve quoted phrases, and update API/skill documentation.
+- Resolve only the requested proxy metadata in parallel after server snapshots are prepared, instead of resolving all five sources sequentially and discarding the server entries.
+- Await complete stream pipelines for artifact/archive downloads, propagate output errors and accept responses without Content-Length.
+- Run all regression tests and both TypeScript projects in CI with lockfile-based installation.
+
+## Measurements
+
+Local Node 24 handler benchmark, same committed dataset, 25 sequential requests per query, limit 50. These measurements include data access and JSON serialization but exclude HTTP transport, Next.js routing overhead and browser rendering. The first request populates the new cache; medians represent repeated requests.
+
+| Query                    | Before median | After median |
+| ------------------------ | ------------: | -----------: |
+| player                   |      16.74 ms |      1.23 ms |
+| join OR login OR connect |      15.96 ms |      1.26 ms |
+| チャット OR chat         |      12.52 ms |      0.51 ms |
+
+Version-list handler mean over 25 requests: 9.03 ms → 0.04 ms.
+
+The Japanese desktop page initially rendered 553 event rows / 5,689 DOM elements; the paginated page rendered 50 rows / 730 elements. Total results remain 553. A burst of search input produced one search API request and no server-component navigation.
+
+Run `npm run benchmark` to repeat the handler benchmark. Absolute timing depends on the machine and cache state; these are not Core Web Vitals or production latency measurements.
+
+## Other findings
+
+- Full virtualization and a database/search-engine migration were deferred: pagination and reuse remove the observed initial rendering and repeated-read costs with the current dataset.
+- Release discovery and remote Javadoc parsing still have broad concurrency and permissive fallback handling. Changing those policies needs dedicated fixture coverage of historical sources and upstream behavior; this PR fixes the independently reproducible stream-completion issue.
+- Dependency upgrades, visual redesign, event description changes and service-worker strategy changes were not needed for the selected fixes.
+- The existing Ko-Fi image lint warnings remain; the images now have dimensions and the desktop trigger is keyboard-operable.
+
+## Verification
+
+- 28 automated tests pass, including pagination beyond 100 results, AND/OR/phrase semantics, language/version/source validation, cache expiry/retry/eviction, HTTP failures, complete stream writes and selective proxy metadata reads.
+- Web and downloader TypeScript checks, lint and the production build pass. Lint reports only the existing two Ko-Fi image warnings.
+- Browser checks cover desktop and 390px mobile layouts, Japanese/English, light/dark themes, keyboard activation, Back/Forward, a burst of input, 150 visible search results, source deselection, and preservation of search/version when changing language.
+- Network-blocking checks cover initial search failure, additional-page failure with 50 existing results retained, version-list failure and successful retries. Invalid version URLs recover through the reset action.
+- Synthetic composition events confirm that IME input produces no search request before composition end, followed by the committed Japanese query. A native OS IME session was not automated.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
     "dev": "next dev --webpack",
     "build": "next build --webpack",
     "start": "next start",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "tsx --test \"src/**/*.test.ts\" \"packages/downloader/src/**/*.test.ts\"",
     "lint": "eslint .",
-    "format": "eslint . --fix && prettier --write ."
+    "format": "eslint . --fix && prettier --write .",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p packages/downloader/tsconfig.json --noEmit",
+    "benchmark": "tsx scripts/benchmark-search.ts"
   },
   "dependencies": {
     "@serwist/next": "9.5.12",

--- a/packages/downloader/src/index.ts
+++ b/packages/downloader/src/index.ts
@@ -58,8 +58,7 @@ const index = async () => {
   }
   if (options.versions.length === 0) {
     const latestServer = await downloadLatestServerSnapshot(discoveredReleases);
-    const sources = await getSources();
-    const proxySources = pickSources(sources, PROXY_SOURCE_NAMES);
+    const proxySources = await getSources(PROXY_SOURCE_NAMES);
     const [lang, events] = await downloadLatestEvents(proxySources);
     await writeProxyEvents(lang, filterEvents(events, PROXY_EVENT_SOURCES));
     await writeProxyVersions(proxySources);
@@ -347,21 +346,19 @@ const writeVersionedJson = async (
 const normalizeEvents = (sources: Record<string, EventType>) =>
   Object.values(sources)
     .sort((a, b) => (a.name + a.source).localeCompare(b.name + b.source))
-    .map(
-      (value): EventType => ({
-        deprecate: value.deprecate,
-        deprecateDescription: value.deprecate
-          ? value.deprecateDescription
-          : undefined,
-        description: value.description,
-        abstract: value.abstract,
-        href: value.href,
-        javadoc: value.javadoc?.replace(/\n/g, "")?.replace(/\s+/g, " "),
-        link: value.link,
-        name: value.name,
-        source: value.source,
-      }),
-    );
+    .map((value): EventType => ({
+      deprecate: value.deprecate,
+      deprecateDescription: value.deprecate
+        ? value.deprecateDescription
+        : undefined,
+      description: value.description,
+      abstract: value.abstract,
+      href: value.href,
+      javadoc: value.javadoc?.replace(/\n/g, "")?.replace(/\s+/g, " "),
+      link: value.link,
+      name: value.name,
+      source: value.source,
+    }));
 
 const toLatestVersionMap = (sources: Record<string, Source>) =>
   Object.fromEntries(
@@ -371,14 +368,6 @@ const toLatestVersionMap = (sources: Record<string, Source>) =>
         ? source.versionLabel
         : `${source.versionLabel} - #${source.buildNumber}`,
     ]),
-  );
-
-const pickSources = (
-  sources: Record<string, Source>,
-  names: readonly string[],
-): Record<string, Source> =>
-  Object.fromEntries(
-    names.filter((name) => sources[name]).map((name) => [name, sources[name]]),
   );
 
 const filterEvents = (

--- a/packages/downloader/src/maven.test.ts
+++ b/packages/downloader/src/maven.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type MultiProgress from "multi-progress";
+import { downloadArtifact } from "./maven";
+
+const artifact = { groupId: "example", artifactId: "api", version: "1.0" };
+const progress = {
+  newBar: () => ({ tick: () => {} }),
+} as unknown as MultiProgress;
+
+test("waits for the complete output file, with and without Content-Length", async (context) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "event-download-"));
+  context.after(() => rm(directory, { recursive: true, force: true }));
+  const body = Buffer.alloc(1024 * 1024, 42);
+  for (const withLength of [true, false]) {
+    context.mock.method(
+      globalThis,
+      "fetch",
+      async () =>
+        new Response(body, {
+          headers: withLength ? { "content-length": String(body.length) } : {},
+        }),
+    );
+    const destination = path.join(directory, String(withLength) + ".jar");
+    await downloadArtifact(
+      progress,
+      "Test",
+      artifact,
+      destination,
+      "https://example.test/",
+    );
+    assert.deepEqual(await readFile(destination), body);
+  }
+});
+test("rejects destination write errors with their original cause", async (context) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "event-download-"));
+  context.after(() => rm(directory, { recursive: true, force: true }));
+  context.mock.method(
+    globalThis,
+    "fetch",
+    async () => new Response("archive", { headers: { "content-length": "7" } }),
+  );
+  await assert.rejects(
+    downloadArtifact(
+      progress,
+      "Test",
+      artifact,
+      path.join(directory, "missing", "a.jar"),
+      "https://example.test/",
+    ),
+    { code: "ENOENT" },
+  );
+});
+test("rejects an interrupted response instead of proceeding to extraction", async (context) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "event-download-"));
+  context.after(() => rm(directory, { recursive: true, force: true }));
+  context.mock.method(
+    globalThis,
+    "fetch",
+    async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(new Error("interrupted"));
+          },
+        }),
+        { headers: { "content-length": "100" } },
+      ),
+  );
+  await assert.rejects(
+    downloadArtifact(
+      progress,
+      "Test",
+      artifact,
+      path.join(directory, "a.jar"),
+      "https://example.test/",
+    ),
+    /interrupted/,
+  );
+});

--- a/packages/downloader/src/maven.ts
+++ b/packages/downloader/src/maven.ts
@@ -1,7 +1,7 @@
 import { format, promisify } from "util";
 import { parseString } from "xml2js";
 import MultiProgress from "multi-progress";
-import { Stream } from "stream";
+import { pipeline } from "stream/promises";
 import { createWriteStream } from "fs";
 import { fetchStream, fetchText } from "./http";
 
@@ -124,26 +124,20 @@ export const downloadArtifact = (
   resolveArtifactUrl(artifact, repository, config).then((url) =>
     fetchStream(url, config).then(({ contentLength: headerValue, stream }) => {
       const contentLength = parseInt(String(headerValue ?? ""), 10);
-      if (Number.isNaN(contentLength)) {
-        throw new Error(
-          `Unable to fetch ${url}. Content-Length: ${String(headerValue ?? "")}`,
-        );
-      }
-      return new Promise<void>((resolve, reject) => {
-        const bar = multiProgress.newBar(
-          `  ${name.padEnd(10, " ")} ${artifact.version.padStart(12, " ")} [:bar] :percent`,
-          {
-            complete: "=",
-            incomplete: " ",
-            width: 20,
-            total: contentLength,
-          },
-        );
-        stream.pipe(createWriteStream(destination));
-        stream.on("data", (chunk: Buffer) => bar.tick(chunk.length));
-        stream.on("end", () => resolve());
-        stream.on("error", () => reject());
-      });
+      const bar =
+        Number.isFinite(contentLength) && contentLength > 0
+          ? multiProgress.newBar(
+              `  ${name.padEnd(10, " ")} ${artifact.version.padStart(12, " ")} [:bar] :percent`,
+              {
+                complete: "=",
+                incomplete: " ",
+                width: 20,
+                total: contentLength,
+              },
+            )
+          : null;
+      if (bar) stream.on("data", (chunk: Buffer) => bar.tick(chunk.length));
+      return pipeline(stream, createWriteStream(destination));
     }),
   );
 

--- a/packages/downloader/src/purpur-patch-events.ts
+++ b/packages/downloader/src/purpur-patch-events.ts
@@ -1,3 +1,4 @@
+import { pipeline } from "stream/promises";
 import { tgz } from "compressing";
 import { createWriteStream } from "fs";
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "fs/promises";
@@ -195,13 +196,7 @@ const parseLegacyPurpurPatch = async (
 
 const downloadArchive = async (url: string, destination: string) => {
   const { stream } = await fetchStream(url);
-  await new Promise<void>((resolve, reject) => {
-    const output = createWriteStream(destination);
-    stream.pipe(output);
-    output.on("close", () => resolve());
-    output.on("error", reject);
-    stream.on("error", reject);
-  });
+  await pipeline(stream, createWriteStream(destination));
 };
 
 const listPatchFiles = async (rootPath: string) => {

--- a/packages/downloader/src/sources/sources.test.ts
+++ b/packages/downloader/src/sources/sources.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { getSources } from "./sources";
+
+test("resolves only requested proxy metadata without depending on server endpoints", async (context) => {
+  const urls: string[] = [];
+  context.mock.method(globalThis, "fetch", async (input: string) => {
+    urls.push(input);
+    if (input.endsWith("/pom.xml"))
+      return new Response("<project><version>1.0-SNAPSHOT</version></project>");
+    if (input.includes("BungeeCord/lastBuild"))
+      return Response.json({ id: "1" });
+    if (input.endsWith("/projects/velocity"))
+      return Response.json({ versions: { "3": ["3.4.0-SNAPSHOT"] } });
+    if (input.endsWith("/projects/velocity/versions/3.4.0-SNAPSHOT"))
+      return Response.json({ builds: [2] });
+    throw new Error(`Unexpected metadata request: ${input}`);
+  });
+  const result = await getSources(["Bungee", "Velocity"]);
+  assert.deepEqual(Object.keys(result), ["Bungee", "Velocity"]);
+  assert.equal(result.Bungee.buildNumber, 1);
+  assert.equal(result.Velocity.buildNumber, 2);
+  assert.equal(urls.length, 4);
+});
+
+test("requesting no sources performs no remote calls", async (context) => {
+  context.mock.method(globalThis, "fetch", async () => {
+    throw new Error("Unexpected fetch");
+  });
+  assert.deepEqual(await getSources([]), {});
+});

--- a/packages/downloader/src/sources/sources.ts
+++ b/packages/downloader/src/sources/sources.ts
@@ -34,75 +34,89 @@ export type Source = {
   downloadSources: SourceType[];
 };
 
-export const getSources = async (): Promise<Record<string, Source>> => ({
-  Bungee: await bungeeVersion().then(async (version) => ({
-    location: {
-      kind: "artifact",
-      artifact: {
-        groupId: "net.md-5",
-        artifactId: "bungeecord-api",
-        version: version.split("-SNAPSHOT")[0],
-        classifier: "javadoc",
-        isSnapShot: true,
+const sourceLoaders = {
+  Bungee: () =>
+    bungeeVersion().then(async (version) => ({
+      location: {
+        kind: "artifact",
+        artifact: {
+          groupId: "net.md-5",
+          artifactId: "bungeecord-api",
+          version: version.split("-SNAPSHOT")[0],
+          classifier: "javadoc",
+          isSnapShot: true,
+        },
+        repository: "https://central.sonatype.com/repository/maven-snapshots/",
       },
-      repository: "https://central.sonatype.com/repository/maven-snapshots/",
-    },
-    versionLabel: normalizeBungeeVersionLabel(version.split("-SNAPSHOT")[0]),
-    allClasses: "allclasses-index.html",
-    downloadSources: ["bungee"],
-    downloadUrl: "https://ci.md-5.net/job/BungeeCord/lastBuild",
-    javadocUrl: "https://ci.md-5.net/job/BungeeCord/ws/api/target/apidocs/",
-    buildNumber: await bungeeBuildNumber(),
-  })),
-  Paper: await paperVersion().then(async (version) => ({
-    location: createPaperLocation(version),
-    versionLabel: version,
-    allClasses: "allclasses-index.html",
-    downloadSources: ["paper"],
-    downloadUrl: "https://papermc.io/downloads/paper",
-    javadocUrl: `https://jd.papermc.io/paper/${version}/`,
-    buildNumber: await paperBuildNumber(version),
-  })),
-  Purpur: await Promise.all([purpurVersion(), purpurReleaseVersion()]).then(
-    async ([minecraftVersion, releaseVersion]) => ({
-      location: createPurpurReleaseLocation(releaseVersion),
-      versionLabel: normalizePurpurVersionLabel(releaseVersion),
+      versionLabel: normalizeBungeeVersionLabel(version.split("-SNAPSHOT")[0]),
       allClasses: "allclasses-index.html",
-      downloadSources: ["purpur"],
-      downloadUrl: `https://purpurmc.org/download/purpur/${minecraftVersion}`,
-      javadocUrl: "https://purpurmc.org/javadoc/",
-      buildNumber: purpurReleaseBuildNumber(releaseVersion),
-    }),
-  ),
-  Spigot: await spigotVersion().then(async (version) => ({
-    location: createSpigotLocation(version),
-    versionLabel: version,
-    allClasses: "allclasses-index.html",
-    downloadSources: ["spigot"],
-    downloadUrl: "",
-    javadocUrl: "https://hub.spigotmc.org/javadocs/spigot/",
-    buildNumber: await spigotBuildNumber(),
-  })),
-  Velocity: await velocityVersion().then(async (version) => ({
-    location: {
-      kind: "artifact",
-      artifact: {
-        groupId: "com.velocitypowered",
-        artifactId: "velocity-api",
-        version: version.split("-SNAPSHOT")[0],
-        classifier: "javadoc",
-        isSnapShot: true,
+      downloadSources: ["bungee"],
+      downloadUrl: "https://ci.md-5.net/job/BungeeCord/lastBuild",
+      javadocUrl: "https://ci.md-5.net/job/BungeeCord/ws/api/target/apidocs/",
+      buildNumber: await bungeeBuildNumber(),
+    })),
+  Paper: () =>
+    paperVersion().then(async (version) => ({
+      location: createPaperLocation(version),
+      versionLabel: version,
+      allClasses: "allclasses-index.html",
+      downloadSources: ["paper"],
+      downloadUrl: "https://papermc.io/downloads/paper",
+      javadocUrl: `https://jd.papermc.io/paper/${version}/`,
+      buildNumber: await paperBuildNumber(version),
+    })),
+  Purpur: () =>
+    Promise.all([purpurVersion(), purpurReleaseVersion()]).then(
+      async ([minecraftVersion, releaseVersion]) => ({
+        location: createPurpurReleaseLocation(releaseVersion),
+        versionLabel: normalizePurpurVersionLabel(releaseVersion),
+        allClasses: "allclasses-index.html",
+        downloadSources: ["purpur"],
+        downloadUrl: `https://purpurmc.org/download/purpur/${minecraftVersion}`,
+        javadocUrl: "https://purpurmc.org/javadoc/",
+        buildNumber: purpurReleaseBuildNumber(releaseVersion),
+      }),
+    ),
+  Spigot: () =>
+    spigotVersion().then(async (version) => ({
+      location: createSpigotLocation(version),
+      versionLabel: version,
+      allClasses: "allclasses-index.html",
+      downloadSources: ["spigot"],
+      downloadUrl: "",
+      javadocUrl: "https://hub.spigotmc.org/javadocs/spigot/",
+      buildNumber: await spigotBuildNumber(),
+    })),
+  Velocity: () =>
+    velocityVersion().then(async (version) => ({
+      location: {
+        kind: "artifact",
+        artifact: {
+          groupId: "com.velocitypowered",
+          artifactId: "velocity-api",
+          version: version.split("-SNAPSHOT")[0],
+          classifier: "javadoc",
+          isSnapShot: true,
+        },
+        repository: "https://repo.papermc.io/repository/maven-public/",
       },
-      repository: "https://repo.papermc.io/repository/maven-public/",
-    },
-    versionLabel: version,
-    allClasses: "allclasses-index.html",
-    downloadSources: ["velocity"],
-    downloadUrl: "https://papermc.io/downloads/velocity",
-    javadocUrl: `https://jd.papermc.io/velocity/${version}/`,
-    buildNumber: await velocityBuildNumber(version),
-  })),
-});
+      versionLabel: version,
+      allClasses: "allclasses-index.html",
+      downloadSources: ["velocity"],
+      downloadUrl: "https://papermc.io/downloads/velocity",
+      javadocUrl: `https://jd.papermc.io/velocity/${version}/`,
+      buildNumber: await velocityBuildNumber(version),
+    })),
+} satisfies Record<string, () => Promise<Source>>;
+
+export const getSources = async (
+  names: readonly (keyof typeof sourceLoaders)[],
+): Promise<Record<string, Source>> =>
+  Object.fromEntries(
+    await Promise.all(
+      names.map(async (name) => [name, await sourceLoaders[name]()]),
+    ),
+  );
 
 export const getSourceType = (href: string): SourceType | null => {
   if (href.startsWith("org/bukkit")) {

--- a/scripts/benchmark-search.ts
+++ b/scripts/benchmark-search.ts
@@ -1,0 +1,31 @@
+import { performance } from "node:perf_hooks";
+import { NextRequest } from "next/server";
+import { searchEvents } from "../src/app/api/search/events/handler";
+import { versionsResponse } from "../src/app/api/versions/handler";
+
+async function measure() {
+  for (const q of ["player", "join OR login OR connect", "チャット OR chat"]) {
+    const samples: number[] = [];
+    let bytes = 0;
+    for (let i = 0; i < 25; i++) {
+      const start = performance.now();
+      const response = await searchEvents(
+        new NextRequest(
+          `http://localhost/api/search/events?q=${encodeURIComponent(q)}&lang=ja&limit=50`,
+        ),
+      );
+      bytes = Buffer.byteLength(await response.text());
+      samples.push(performance.now() - start);
+    }
+    samples.sort((a, b) => a - b);
+    console.log(
+      JSON.stringify({ q, medianMs: samples[12], p95Ms: samples[23], bytes }),
+    );
+  }
+  const start = performance.now();
+  for (let i = 0; i < 25; i++) await (await versionsResponse()).text();
+  console.log(
+    JSON.stringify({ versionsMeanMs: (performance.now() - start) / 25 }),
+  );
+}
+void measure();

--- a/skills/spigot-event-search/SKILL.md
+++ b/skills/spigot-event-search/SKILL.md
@@ -22,6 +22,8 @@ Use this skill when a user wants to find events from partial text rather than br
 - Supports `latest` or a fixed Minecraft version such as `1.21.11`
 - Accepts the current `latestMinecraftVersion` as an explicit, non-persistent
   alias for the latest merged dataset
+- Supports paginated results using `total` and `nextOffset`; continue with the returned offset when more candidates are needed
+- Descriptions are localized strings selected with `lang=ja` or `lang=en`
 - Supports source filtering for `spigot`, `paper`, `purpur`, `bungee`, `velocity`
 
 ## API

--- a/skills/spigot-event-search/references/api.md
+++ b/skills/spigot-event-search/references/api.md
@@ -1,102 +1,71 @@
 # API Reference
 
-Endpoint:
-
-```text
-GET https://spigot-event-list.s7a.dev/api/search/events
-```
+`GET https://spigot-event-list.s7a.dev/api/search/events`
 
 ## Query parameters
 
-- `q` required
-  - Partial-match search text
-  - Queries in supported dataset languages are supported
-  - Searches event name, descriptions, Javadoc, and deprecation descriptions
-  - Supports `OR` and `AND`
-  - Whitespace-separated terms are treated as `AND`
-  - Quoted phrases such as `"block break"` are supported
-- `version` optional
-  - `latest` or a fixed Minecraft version such as `1.21.11`
-  - Default: `latest`
-  - The current `latestMinecraftVersion` returned by `GET /api/versions` is
-    accepted as an explicit alias for the latest merged dataset.
-- `source` optional
-  - Comma-separated list from `spigot,paper,purpur,bungee,velocity`
-- `limit` optional
-  - Integer from `1` to `100`
-  - Default: `20`
+- `q`: optional partial-match search across event names, all description languages, Javadoc and deprecation descriptions. Omitted or blank queries browse all events.
+  - Whitespace and `AND` require all terms. `OR` separates alternatives.
+  - Quoted phrases stay contiguous; quoted operators are literal text.
+  - A nonempty query containing only ignored words/operators returns zero matches.
+- `version`: `latest` (default) or a value from `GET /api/versions`.
+  - The current `latestMinecraftVersion` is an explicit alias for the latest merged data, only while those values agree.
+  - Historical versions combine their server events with the latest proxy events.
+- `source`: comma-separated values from `spigot,paper,purpur,bungee,velocity`. Omitted selects all; an explicitly empty value selects none. Unknown values do not match.
+- `lang`: response description language, `ja` (default) or `en`. Search still covers all dataset languages.
+- `limit`: page size, 1–100 (default 20).
+- `offset`: nonnegative integer starting position (default 0).
+
+Integer pagination values are clamped to their bounds; malformed/non-integer values use the defaults.
 
 ## Example
 
 ```bash
-curl -fsSL 'https://spigot-event-list.s7a.dev/api/search/events?q=login&source=velocity,bungee&limit=5'
-```
-
-```bash
+curl -fsSL 'https://spigot-event-list.s7a.dev/api/search/events?q=login&source=velocity,bungee&lang=en&limit=5'
 curl -fsSL 'https://spigot-event-list.s7a.dev/api/search/events?q=chat%20OR%20login&version=latest'
-```
-
-```bash
-curl -fsSL 'https://spigot-event-list.s7a.dev/api/search/events?q=%22block%20break%22%20paper'
-```
-
-```bash
-curl -fsSL 'https://spigot-event-list.s7a.dev/api/search/events?q=join%20OR%20login%20OR%20connect'
-```
-
-```bash
-curl -fsSL 'https://spigot-event-list.s7a.dev/api/search/events?q=%E5%8F%82%E5%8A%A0%20OR%20%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%20OR%20join%20OR%20login'
+curl -fsSL 'https://spigot-event-list.s7a.dev/api/search/events?q=%22block%20break%22'
+curl -fsSL 'https://spigot-event-list.s7a.dev/api/search/events?q=player&limit=50&offset=100'
 ```
 
 ## Response
+
+Descriptions are localized strings. `count` is the size of this page; `total` counts all matching events before pagination. Request the same query, filters and limit with `offset=nextOffset` to continue. A null `nextOffset` marks the end.
 
 ```json
 {
   "query": "login",
   "version": "latest",
-  "count": 2,
+  "count": 1,
+  "total": 1,
+  "offset": 0,
+  "nextOffset": null,
   "events": [
     {
       "version": "latest",
       "name": "LoginEvent",
       "source": "velocity",
-      "link": "https://...",
-      "description": {
-        "ja": "...",
-        "en": "..."
-      },
-      "deprecateDescription": {
-        "ja": "...",
-        "en": "..."
-      },
-      "javadoc": "..."
+      "link": "https://example.com/LoginEvent.html",
+      "description": "Localized description",
+      "deprecateDescription": "Optional localized deprecation description",
+      "javadoc": "Optional original Javadoc text"
     }
   ]
 }
 ```
 
-## Notes
+Results sort by relevance, then name, source and link. Browsing uses name, source and link order. An offset beyond the result set returns an empty page with the original total.
 
-- `latest` returns the latest merged dataset.
-- An explicit version equal to the current `latestMinecraftVersion` also reads
-  the latest merged dataset. The response keeps the explicitly requested
-  version in both the top-level `version` and each result's `version`.
-- The alias is evaluated against the current latest version on every request.
-  After latest advances, the previous version uses its fixed snapshot when one
-  exists, or returns `404 Unsupported version` when one does not; it never
-  follows newer latest data.
-- Fixed versions include the selected Minecraft server data plus the latest proxy data.
-- Results are sorted by relevance, then by name and source.
-- `A B` means `A AND B`.
-- `A OR B` means either term may match.
-- `A OR B OR C` is useful when you want to try several likely candidate words.
-- Mixing a supported non-English language with English in the same OR query is allowed when it improves recall.
-- If the user's language is not supported by the dataset, use English-only query expansion.
+Unsupported versions return HTTP 404; unsupported languages return HTTP 400. These errors use plain-text bodies. Other failures can return HTTP 500; check the HTTP status before decoding JSON.
 
-## Version discovery
+## Related endpoints and freshness
 
-`GET /api/versions` returns the `latest` alias, `latestMinecraftVersion`, and
-the accepted version values. `latestMinecraftVersion` is only set when the
-latest Paper, Purpur, and Spigot datasets all identify the same stable
-Minecraft version. It is `null`, and no explicit latest-version alias is
-advertised, while those server sources disagree during an update.
+- `GET /api/versions` returns `latest`, `latestMinecraftVersion` (string or null) and accepted `versions`.
+- `GET /api/versions/{version}/events?lang=ja` returns a localized array of all events for that version.
+- Web server data reads are cached for at most 60 seconds after each successful load, with a bounded cache. Failed loads are retried on the next request. Downloader reads remain uncached.
+
+## Search guidance
+
+- Use `A B` or `A AND B` when both conditions should match.
+- Use `A OR B` for alternatives or synonyms.
+- Mix Japanese and English alternatives when helpful, for example `参加 OR ログイン OR join OR login`.
+- Use English expansion for languages absent from the dataset.

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,21 +1,10 @@
-import { splitTags } from "@/libs/event-source-tag";
+import { Suspense } from "react";
 import EventListPage from "@/components/event-list-page";
 
-export default async function Page({
-  searchParams,
-}: {
-  searchParams: Promise<{
-    tags?: string;
-    search?: string;
-    version?: string;
-  }>;
-}) {
-  const resolvedSearchParams = await searchParams;
+export default function Page() {
   return (
-    <EventListPage
-      defaultSearch={resolvedSearchParams.search ?? ""}
-      defaultTags={splitTags(resolvedSearchParams.tags)}
-      defaultVersion={resolvedSearchParams.version ?? "latest"}
-    />
+    <Suspense>
+      <EventListPage />
+    </Suspense>
   );
 }

--- a/src/app/api/search/events/handler.ts
+++ b/src/app/api/search/events/handler.ts
@@ -1,324 +1,81 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  getLatestMinecraftVersion,
-  getServerVersionsDesc,
-  readLatestServerEvents,
-  readProxyEvents,
-  readServerEvents,
-  resolveServerVersion,
-} from "@/libs/data-paths";
 import EventSource from "@/types/event-source";
-import EventType from "../../../../../packages/downloader/src/types/event-type";
+import type { SearchEventsResponse } from "@/types/event";
+import {
+  eventDataDependencies,
+  readEventData,
+  localizeEvent,
+  compareEvents,
+  type EventDataDependencies,
+} from "@/libs/event-data";
+import { parseQuery, scoreEvent } from "@/libs/event-search";
 
-type SearchEventResponse = {
-  version: string;
-  name: string;
-  source: EventSource;
-  link: string;
-  abstract?: true;
-  deprecate?: string;
-  description: string;
-  deprecateDescription?: string;
-  javadoc?: string;
-};
-
-type QueryTerm = {
-  normalized: string;
-};
-
-type QueryClause = {
-  terms: QueryTerm[];
-};
-
-type SearchEventsDependencies = {
-  getLatestMinecraftVersion: typeof getLatestMinecraftVersion;
-  getServerVersionsDesc: typeof getServerVersionsDesc;
-  readLatestServerEvents: typeof readLatestServerEvents;
-  readProxyEvents: typeof readProxyEvents;
-  readServerEvents: typeof readServerEvents;
-};
-
-const normalize = (value: string | null | undefined) =>
-  (value ?? "").replace(/\s+/g, " ").trim().toLocaleLowerCase();
-
-const englishStopWords = new Set([
-  "a",
-  "an",
-  "and",
-  "at",
-  "by",
-  "for",
-  "from",
-  "in",
-  "into",
-  "is",
-  "of",
-  "on",
-  "the",
-  "to",
-  "when",
-]);
-
-const normalizeJapaneseQueryEnding = (value: string) => {
-  const suffixes = [
-    "されていたとき",
-    "されていた時",
-    "していたとき",
-    "していた時",
-    "されたとき",
-    "された時",
-    "するとき",
-    "する時",
-    "したとき",
-    "した時",
-    "である",
-    "でした",
-    "だった",
-    "されていた",
-    "していた",
-    "された",
-    "している",
-    "される",
-    "します",
-    "する",
-    "した",
-    "です",
-    "だ",
-  ];
-  for (const suffix of suffixes) {
-    if (value.endsWith(suffix) && value.length > suffix.length + 1) {
-      return value.slice(0, -suffix.length);
-    }
-  }
-  return value;
-};
-
-const normalizeQueryTerm = (value: string) => {
-  const normalized = normalize(value);
-  if (englishStopWords.has(normalized)) {
-    return "";
-  }
-  if (/^[a-z]+ies$/.test(normalized)) {
-    return `${normalized.slice(0, -3)}y`;
-  }
-  if (/^[a-z]+(?:ches|shes|xes|zes|ses)$/.test(normalized)) {
-    return normalized.slice(0, -2);
-  }
-  if (/^[a-z]{4,}s$/.test(normalized)) {
-    return normalized.slice(0, -1);
-  }
-  return normalizeJapaneseQueryEnding(normalized);
-};
-
-const tokenizeQuery = (value: string) =>
-  Array.from(
-    value.matchAll(/"([^"]+)"|'([^']+)'|\bAND\b|\bOR\b|[^\s]+/gi),
-    (match) => match[1] ?? match[2] ?? match[0] ?? "",
-  ).filter((token) => token.length > 0);
-
-const parseQuery = (value: string): QueryClause[] => {
-  const clauses: QueryClause[] = [];
-  let currentTerms: QueryTerm[] = [];
-  let pendingAnd = false;
-
-  for (const token of tokenizeQuery(value)) {
-    const upper = token.toUpperCase();
-    if (upper === "OR") {
-      if (currentTerms.length > 0) {
-        clauses.push({ terms: currentTerms });
-        currentTerms = [];
-      }
-      pendingAnd = false;
-      continue;
-    }
-    if (upper === "AND") {
-      pendingAnd = currentTerms.length > 0;
-      continue;
-    }
-    const normalized = normalizeQueryTerm(token);
-    if (!normalized) {
-      continue;
-    }
-    if (currentTerms.length > 0 && !pendingAnd) {
-      clauses.push({ terms: currentTerms });
-      currentTerms = [];
-    }
-    currentTerms.push({ normalized });
-    pendingAnd = false;
-  }
-
-  if (currentTerms.length > 0) {
-    clauses.push({ terms: currentTerms });
-  }
-
-  return clauses;
-};
-
-const splitSources = (value: string | null) =>
-  (value ?? "")
-    .split(",")
-    .map((item) => item.trim())
-    .filter((item): item is EventSource =>
-      (EventSource as readonly string[]).includes(item),
-    );
-
-const parseLimit = (value: string | null) => {
-  const parsed = Number.parseInt(value ?? "", 10);
-  if (Number.isNaN(parsed)) {
-    return 20;
-  }
-  return Math.min(Math.max(parsed, 1), 100);
-};
-
-const localizedValues = (value: Record<string, string> | undefined) =>
-  Object.values(value ?? {});
-
-const matchTermScore = (event: EventType, term: QueryTerm) => {
-  const lowerName = normalize(event.name);
-  if (lowerName === term.normalized) {
-    return 500;
-  }
-  if (lowerName.includes(term.normalized)) {
-    return 350;
-  }
-
-  const descriptionMatches = localizedValues(event.description)
-    .map((value) => normalize(value))
-    .filter((value) => value.includes(term.normalized)).length;
-  if (descriptionMatches > 0) {
-    return 220 + descriptionMatches * 10;
-  }
-
-  if (normalize(event.javadoc).includes(term.normalized)) {
-    return 120;
-  }
-
-  const deprecateMatches = localizedValues(event.deprecateDescription)
-    .map((value) => normalize(value))
-    .filter((value) => value.includes(term.normalized)).length;
-  if (deprecateMatches > 0) {
-    return 70 + deprecateMatches * 5;
-  }
-
-  return 0;
-};
-
-const scoreEvent = (event: EventType, clauses: QueryClause[]) => {
-  let totalScore = 0;
-
-  for (const clause of clauses) {
-    const termScores = clause.terms.map((term) => matchTermScore(event, term));
-    if (termScores.some((score) => score === 0)) {
-      continue;
-    }
-    totalScore +=
-      termScores.reduce((total, score) => total + score, 0) +
-      clause.terms.length * 25;
-  }
-
-  return totalScore;
-};
-
-const readEventsForVersion = async (
-  version: string,
-  dependencies: SearchEventsDependencies,
+const integerParam = (
+  value: string | null,
+  fallback: number,
+  min: number,
+  max: number,
 ) => {
-  if (version === "latest") {
-    return dependencies.readLatestServerEvents();
-  }
-  const [serverData, proxyData] = await Promise.all([
-    dependencies.readServerEvents(version),
-    dependencies.readProxyEvents(),
-  ]);
-  return {
-    lang: serverData.lang,
-    events: [...serverData.events, ...proxyData.events],
-  };
+  const parsed = Number(value ?? fallback);
+  return Number.isSafeInteger(parsed)
+    ? Math.min(Math.max(parsed, min), max)
+    : fallback;
 };
 
 export const createSearchEventsHandler =
-  (dependencies: SearchEventsDependencies) => async (request: NextRequest) => {
-    const rawQuery = request.nextUrl.searchParams.get("q") ?? "";
+  (dependencies: EventDataDependencies) => async (request: NextRequest) => {
+    const params = request.nextUrl.searchParams;
+    const rawQuery = params.get("q") ?? "";
     const clauses = parseQuery(rawQuery);
-    if (clauses.length === 0) {
-      return new NextResponse("Missing query: q", { status: 400 });
-    }
-
-    const version = request.nextUrl.searchParams.get("version") ?? "latest";
-    const [availableVersions, latestMinecraftVersion] = await Promise.all([
-      dependencies.getServerVersionsDesc(),
-      dependencies.getLatestMinecraftVersion(),
-    ]);
-    const versionResolution = resolveServerVersion(
-      version,
-      availableVersions,
-      latestMinecraftVersion,
-    );
-    if (!versionResolution) {
+    const version = params.get("version") || "latest";
+    const data = await readEventData(version, dependencies);
+    if (!data)
       return new NextResponse(`Unsupported version: ${version}`, {
         status: 404,
       });
-    }
-
-    const sources = splitSources(request.nextUrl.searchParams.get("source"));
-    const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
-    const data = await readEventsForVersion(
-      versionResolution.resolvedVersion,
-      dependencies,
+    const lang = params.get("lang") ?? "ja";
+    if (!data.lang.includes(lang))
+      return new NextResponse(`Unsupported lang: ${lang}`, { status: 400 });
+    const sourceParam = params.get("source");
+    const sources =
+      sourceParam === null
+        ? [...EventSource]
+        : sourceParam.split(",").map((value) => value.trim());
+    const limit = integerParam(params.get("limit"), 20, 1, 100);
+    const offset = integerParam(
+      params.get("offset"),
+      0,
+      0,
+      Number.MAX_SAFE_INTEGER,
     );
-    const lang = request.nextUrl.searchParams.get("lang") ?? "ja";
-    if (!data.lang.includes(lang)) {
-      return new NextResponse(`Unsupported lang: ${lang}`, {
-        status: 400,
-      });
-    }
-
+    const browsing = rawQuery.trim().length === 0;
     const matches = data.events
-      .filter((event) =>
-        sources.length === 0
-          ? true
-          : sources.includes(event.source as EventSource),
-      )
+      .filter((event) => sources.includes(event.source))
       .map((event) => ({
         event,
-        score: scoreEvent(event, clauses),
+        score: browsing ? 1 : scoreEvent(event, clauses),
       }))
       .filter(({ score }) => score > 0)
-      .sort((left, right) => {
-        if (right.score !== left.score) {
-          return right.score - left.score;
-        }
-        const nameComparison = left.event.name.localeCompare(right.event.name);
-        if (nameComparison !== 0) {
-          return nameComparison;
-        }
-        return left.event.source.localeCompare(right.event.source);
-      })
-      .slice(0, limit)
-      .map(({ event }): SearchEventResponse => ({
-        version,
-        name: event.name,
-        source: event.source as EventSource,
-        link: event.link,
-        abstract: event.abstract,
-        deprecate: event.deprecate,
-        description: event.description[lang],
-        deprecateDescription: event.deprecateDescription?.[lang],
-        javadoc: event.javadoc,
-      }));
-
-    return NextResponse.json({
+      .sort(
+        (left, right) =>
+          right.score - left.score || compareEvents(left.event, right.event),
+      );
+    const events = matches.slice(offset, offset + limit).map(({ event }) => ({
+      ...localizeEvent(event, lang),
+      version,
+      javadoc: event.javadoc,
+    }));
+    const result: SearchEventsResponse = {
       query: rawQuery,
       version,
-      count: matches.length,
-      events: matches,
-    });
+      count: events.length,
+      total: matches.length,
+      offset,
+      nextOffset:
+        offset + events.length < matches.length ? offset + events.length : null,
+      events,
+    };
+    return NextResponse.json(result);
   };
 
-export const searchEvents = createSearchEventsHandler({
-  getLatestMinecraftVersion,
-  getServerVersionsDesc,
-  readLatestServerEvents,
-  readProxyEvents,
-  readServerEvents,
-});
+export const searchEvents = createSearchEventsHandler(eventDataDependencies);

--- a/src/app/api/search/events/route.test.ts
+++ b/src/app/api/search/events/route.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import { NextRequest } from "next/server";
 import EventType from "../../../../../packages/downloader/src/types/event-type";
 import { createSearchEventsHandler } from "./handler";
+import type { SearchEventsResponse } from "@/types/event";
 
 const paperEvent: EventType = {
   description: {
@@ -16,6 +17,110 @@ const paperEvent: EventType = {
 };
 
 const eventData = { lang: ["en", "ja"], events: [paperEvent] };
+
+const makeHandler = (events: EventType[] = [paperEvent]) =>
+  createSearchEventsHandler({
+    getLatestMinecraftVersion: async () => "26.2",
+    getServerVersionsDesc: async () => ["26.1.2"],
+    readLatestServerEvents: async () => ({ lang: ["en", "ja"], events }),
+    readServerEvents: async () => ({ lang: ["en", "ja"], events }),
+    readProxyEvents: async () => ({
+      lang: ["en", "ja"],
+      events: [{ ...paperEvent, name: "ProxyEvent", source: "velocity" }],
+    }),
+  });
+
+test("paginates beyond 100 matches without losing or duplicating events", async () => {
+  const events = Array.from({ length: 137 }, (_, index) => ({
+    ...paperEvent,
+    name: `Event${String(index).padStart(3, "0")}`,
+  }));
+  const handler = makeHandler(events.reverse());
+  const found: string[] = [];
+  let offset: number | null = 0;
+  while (offset !== null) {
+    const response = await handler(
+      new NextRequest(
+        `https://example.test/api/search/events?q=event&limit=50&offset=${offset}`,
+      ),
+    );
+    const data = (await response.json()) as SearchEventsResponse;
+    assert.equal(data.total, 137);
+    assert.equal(data.offset, offset);
+    assert.equal(data.count, data.events.length);
+    found.push(...data.events.map((event) => event.name));
+    offset = data.nextOffset;
+  }
+  assert.equal(found.length, 137);
+  assert.equal(new Set(found).size, 137);
+  assert.deepEqual(found, [...found].sort());
+});
+
+test("browses without a query and applies source filters before pagination", async () => {
+  const handler = makeHandler([
+    { ...paperEvent, source: "spigot" },
+    paperEvent,
+  ]);
+  const response = await handler(
+    new NextRequest(
+      "https://example.test/api/search/events?source=paper&limit=1&lang=en",
+    ),
+  );
+  const data = (await response.json()) as SearchEventsResponse;
+  assert.equal(data.total, 1);
+  assert.equal(data.events[0].source, "paper");
+  assert.equal(data.events[0].description, paperEvent.description.en);
+  assert.equal(data.nextOffset, null);
+});
+
+test("empty selections, stop words and no matches return successful empty results", async () => {
+  for (const query of [
+    "source=",
+    "source=unknown",
+    "q=the",
+    "q=absent",
+    "offset=1000",
+  ]) {
+    const response = await makeHandler()(
+      new NextRequest(`https://example.test/api/search/events?${query}`),
+    );
+    assert.equal(response.status, 200);
+    const data = (await response.json()) as SearchEventsResponse;
+    assert.deepEqual(data.events, []);
+    assert.equal(data.nextOffset, null);
+  }
+});
+
+test("invalid pagination parameters are bounded and unsupported languages fail clearly", async () => {
+  for (const query of [
+    "limit=0&offset=-1",
+    "limit=oops&offset=NaN",
+    "limit=1.5&offset=Infinity",
+  ]) {
+    const response = await makeHandler()(
+      new NextRequest(`https://example.test/api/search/events?${query}`),
+    );
+    const data = (await response.json()) as SearchEventsResponse;
+    assert.equal(data.count, 1);
+    assert.equal(data.offset, 0);
+  }
+  const response = await makeHandler()(
+    new NextRequest("https://example.test/api/search/events?lang=unsupported"),
+  );
+  assert.equal(response.status, 400);
+});
+
+test("historical searches include current proxy events exactly once", async () => {
+  const response = await makeHandler()(
+    new NextRequest("https://example.test/api/search/events?version=26.1.2"),
+  );
+  const data = (await response.json()) as SearchEventsResponse;
+  assert.equal(data.total, 2);
+  assert.deepEqual(
+    data.events.map((event) => event.source),
+    ["paper", "velocity"],
+  );
+});
 
 test("searches the current explicit Minecraft version in latest data without changing the response version", async () => {
   const calls = { latest: 0, proxy: 0, fixed: [] as string[] };

--- a/src/app/api/versions/[version]/events/handler.ts
+++ b/src/app/api/versions/[version]/events/handler.ts
@@ -1,108 +1,32 @@
 import { NextRequest, NextResponse } from "next/server";
-import { map, pick, pipe, sortBy } from "remeda";
 import {
-  getLatestMinecraftVersion,
-  getServerVersionsDesc,
-  readLatestServerEvents,
-  readProxyEvents,
-  readServerEvents,
-  resolveServerVersion,
-} from "@/libs/data-paths";
-import EventSource from "@/types/event-source";
-
-type EventResponse = {
-  name: string;
-  description: string;
-  link: string;
-  abstract?: true;
-  source: EventSource;
-  deprecate?: string;
-  deprecateDescription?: string;
-};
-
-type VersionEventsDependencies = {
-  getLatestMinecraftVersion: typeof getLatestMinecraftVersion;
-  getServerVersionsDesc: typeof getServerVersionsDesc;
-  readLatestServerEvents: typeof readLatestServerEvents;
-  readProxyEvents: typeof readProxyEvents;
-  readServerEvents: typeof readServerEvents;
-};
+  eventDataDependencies,
+  readEventData,
+  localizeEvent,
+  compareEvents,
+  type EventDataDependencies,
+} from "@/libs/event-data";
 
 export const createVersionEventsHandler =
-  (dependencies: VersionEventsDependencies) =>
+  (dependencies: EventDataDependencies) =>
   async (
     request: NextRequest,
     { params }: { params: Promise<{ version: string }> },
   ) => {
     const { version } = await params;
-    const [availableVersions, latestMinecraftVersion] = await Promise.all([
-      dependencies.getServerVersionsDesc(),
-      dependencies.getLatestMinecraftVersion(),
-    ]);
-    const versionResolution = resolveServerVersion(
-      version,
-      availableVersions,
-      latestMinecraftVersion,
-    );
-    if (!versionResolution) {
+    const data = await readEventData(version, dependencies);
+    if (!data)
       return new NextResponse(`Unsupported version: ${version}`, {
         status: 404,
       });
-    }
-    const isLatest = versionResolution.resolvedVersion === "latest";
-    const serverData = isLatest
-      ? await dependencies.readLatestServerEvents()
-      : await dependencies.readServerEvents(versionResolution.resolvedVersion);
-    const proxyData = isLatest ? null : await dependencies.readProxyEvents();
     const lang = request.nextUrl.searchParams.get("lang") ?? "ja";
-    if (!serverData.lang.includes(lang)) {
-      return new NextResponse(`Unsupported lang: ${lang}`, {
-        status: 400,
-      });
-    }
+    if (!data.lang.includes(lang))
+      return new NextResponse(`Unsupported lang: ${lang}`, { status: 400 });
     return NextResponse.json(
-      pipe(
-        [...serverData.events, ...(proxyData?.events ?? [])],
-        sortBy(
-          [(event) => event.name, "asc"],
-          [(event) => event.source, "asc"],
-        ),
-        map(
-          pick([
-            "name",
-            "description",
-            "link",
-            "abstract",
-            "source",
-            "deprecate",
-            "deprecateDescription",
-          ]),
-        ),
-        map((event): EventResponse => {
-          const description = (event.description as Record<string, string>)[
-            lang
-          ];
-          const deprecateDescription = event.deprecateDescription
-            ? (event.deprecateDescription as Record<string, string>)[lang]
-            : undefined;
-          return {
-            name: event.name as string,
-            description,
-            link: event.link as string,
-            abstract: event.abstract as true | undefined,
-            source: event.source as EventSource,
-            deprecate: event.deprecate as string | undefined,
-            deprecateDescription,
-          };
-        }),
-      ),
+      [...data.events]
+        .sort(compareEvents)
+        .map((event) => localizeEvent(event, lang)),
     );
   };
 
-export const versionEvents = createVersionEventsHandler({
-  getLatestMinecraftVersion,
-  getServerVersionsDesc,
-  readLatestServerEvents,
-  readProxyEvents,
-  readServerEvents,
-});
+export const versionEvents = createVersionEventsHandler(eventDataDependencies);

--- a/src/components/event-list-page.tsx
+++ b/src/components/event-list-page.tsx
@@ -2,181 +2,101 @@
 
 import Link from "next/link";
 import { FaFaucet } from "react-icons/fa";
-import SearchBox from "@/components/search-box";
-import EventSource from "@/types/event-source";
-import SelectableSourceTag from "@/components/selectable-source-tag";
-import EventList from "@/components/event-list";
-import SwitchThemeButton from "@/components/switch-theme-button";
-import { FC, useMemo, useState, useSyncExternalStore } from "react";
-import { useEffect } from "react";
-import { Locale } from "@/i18n/config";
-import { BsTranslate } from "react-icons/bs";
-import { FiPlus } from "react-icons/fi";
 import { FiMenu, FiX } from "react-icons/fi";
-import { FiCheck, FiCopy, FiExternalLink } from "react-icons/fi";
-import { TbRobotFace } from "react-icons/tb";
+import { useState } from "react";
+import clsx from "clsx";
+import SearchBox from "./search-box";
+import SelectableSourceTag from "./selectable-source-tag";
+import EventList from "./event-list";
+import SiteFooter from "./site-footer";
+import EventSource from "@/types/event-source";
 import { translate } from "@/i18n/translation";
 import useLocale from "@/i18n/use-locale";
-import { KoFiButton } from "@/components/ko-fi-button";
 import useVersions from "@/libs/hooks/use-versions";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEventFilters } from "@/libs/hooks/use-event-filters";
 
-export type EventListPageProps = {
-  defaultSearch: string;
-  defaultTags: EventSource[];
-  defaultVersion: string;
-};
-
-const AI_SKILL_BANNER_DISMISSED_KEY = "spigot-event-list.ai-skill.dismissed";
-const AI_SKILL_GH_LABEL = "GitHub CLI";
-const AI_SKILL_SKILLS_LABEL = "vercel-labs/skills";
-
-const subscribeHydration = () => () => {};
-
-const subscribeBannerDismissed = (onStoreChange: () => void) => {
-  window.addEventListener("storage", onStoreChange);
-  return () => window.removeEventListener("storage", onStoreChange);
-};
-
-const getHydrationSnapshot = () => true;
-const getHydrationServerSnapshot = () => false;
-
-const getBannerDismissedSnapshot = () =>
-  window.localStorage.getItem(AI_SKILL_BANNER_DISMISSED_KEY) === "true";
-
-const getBannerDismissedServerSnapshot = () => false;
-
-const updateBannerDismissed = (dismissed: boolean) => {
-  window.localStorage.setItem(
-    AI_SKILL_BANNER_DISMISSED_KEY,
-    dismissed ? "true" : "false",
-  );
-  window.dispatchEvent(
-    new StorageEvent("storage", { key: AI_SKILL_BANNER_DISMISSED_KEY }),
-  );
-};
-
-const EventListPage: FC<EventListPageProps> = ({
-  defaultSearch,
-  defaultTags,
-  defaultVersion,
-}) => {
+export default function EventListPage() {
   const locale = useLocale();
-  const [search, setSearch] = useState(defaultSearch);
-  const [tags, setTags] = useState(defaultTags);
-  const [version, setVersion] = useState(defaultVersion);
+  const { search, tags, version, setSearch, setTags, setVersion, reset } =
+    useEventFilters();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [copiedCommand, setCopiedCommand] = useState<"gh" | "skills" | null>(
-    null,
+  const {
+    versions,
+    error: versionsError,
+    retry: retryVersions,
+  } = useVersions();
+  const versionOptions = Array.from(
+    new Set(["latest", ...(versions ?? []), version]),
   );
-  const pathname = usePathname();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const { versions, latestVersion } = useVersions();
-  const currentYear = new Date().getFullYear();
-  const aiSkillHydrated = useSyncExternalStore(
-    subscribeHydration,
-    getHydrationSnapshot,
-    getHydrationServerSnapshot,
-  );
-  const aiSkillBannerDismissed = useSyncExternalStore(
-    subscribeBannerDismissed,
-    getBannerDismissedSnapshot,
-    getBannerDismissedServerSnapshot,
-  );
-  const versionOptions = useMemo(() => {
-    const fallbackVersion = version || latestVersion || "latest";
-    return versions && versions.length > 0 ? versions : [fallbackVersion];
-  }, [latestVersion, version, versions]);
-  useEffect(() => {
-    if (!version) {
-      return;
-    }
-    const currentVersion = searchParams.get("version") ?? "latest";
-    if (currentVersion === version) {
-      return;
-    }
-    const nextParams = new URLSearchParams(searchParams.toString());
-    if (version === "latest") {
-      nextParams.delete("version");
-    } else {
-      nextParams.set("version", version);
-    }
-    const nextQuery = nextParams.toString();
-    const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
-    router.replace(nextUrl, { scroll: false });
-  }, [pathname, router, searchParams, version]);
 
-  const closeAiSkillBanner = () => updateBannerDismissed(true);
-
-  const copyCommand = async (kind: "gh" | "skills", value: string) => {
-    await navigator.clipboard.writeText(value);
-    setCopiedCommand(kind);
-    window.setTimeout(() => {
-      setCopiedCommand((current) => (current === kind ? null : current));
-    }, 1500);
-  };
-
-  return [
-    <header
-      key="header"
-      className="z-10 bg-base-300 top-0 sticky border-base-content/10"
-    >
-      <div className="w-full max-w-4xl mx-auto p-2">
-        <div className="flex justify-between gap-3 md:hidden">
-          <Link href="/" className="flex items-center gap-1.5 shrink-0">
-            <FaFaucet className="size-8 fill-current" />
-            <h1 className="font-bold text-xl leading-none">
-              Spigot Event List
-            </h1>
-          </Link>
-          <button
-            type="button"
-            className="btn btn-square btn-ghost btn-sm"
-            aria-label="Toggle filters"
-            onClick={() => setMobileMenuOpen((current) => !current)}
-          >
-            {mobileMenuOpen ? (
-              <FiX className="size-5" />
-            ) : (
-              <FiMenu className="size-5" />
-            )}
-          </button>
-        </div>
-        <div className="hidden md:flex md:items-center md:gap-3">
-          <Link href="/" className="flex items-center gap-1.5 shrink-0">
-            <FaFaucet className="size-6 fill-current" />
-            <h1 className="font-bold text-xl leading-none">
-              Spigot Event List
-            </h1>
-          </Link>
-          <div className="flex min-w-0 flex-1 items-end gap-3">
-            <div className="flex min-w-0 flex-1 flex-col gap-2">
+  return (
+    <>
+      <a
+        href="#event-results"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 btn"
+      >
+        {translate(locale, "SkipToResults")}
+      </a>
+      <header className="z-10 bg-base-300 top-0 sticky border-base-content/10">
+        <div className="w-full max-w-4xl mx-auto p-2">
+          <div className="flex flex-wrap items-center gap-2 md:gap-3">
+            <Link
+              href={`/${locale}`}
+              className="flex items-center gap-1.5 shrink-0"
+            >
+              <FaFaucet className="size-6 fill-current" />
+              <h1 className="font-bold text-xl leading-none">
+                Spigot Event List
+              </h1>
+            </Link>
+            <button
+              type="button"
+              className="btn btn-square btn-ghost btn-sm ml-auto md:hidden"
+              aria-label={translate(locale, "Filters")}
+              aria-expanded={mobileMenuOpen}
+              aria-controls="event-filters"
+              onClick={() => setMobileMenuOpen((current) => !current)}
+            >
+              {mobileMenuOpen ? (
+                <FiX className="size-5" />
+              ) : (
+                <FiMenu className="size-5" />
+              )}
+            </button>
+            <div className="w-full min-w-0 md:w-auto md:flex-1">
               <SearchBox
                 locale={locale}
                 search={search}
                 setSearch={setSearch}
               />
-              <div className="flex gap-1 overflow-x-auto">
-                <div className="flex min-w-max gap-1">
-                  {EventSource.map((source) => (
-                    <SelectableSourceTag
-                      key={source}
-                      source={source}
-                      tags={tags}
-                      setTags={setTags}
-                    />
-                  ))}
-                </div>
-              </div>
             </div>
-            <fieldset className="fieldset w-40 shrink-0">
-              <legend className="fieldset-legend text-xs font-medium">
-                {translate(locale, "Version")}
-              </legend>
+          </div>
+          <div
+            id="event-filters"
+            className={clsx(
+              "mt-2 flex-col gap-2 md:flex md:flex-row md:items-center md:justify-between",
+              mobileMenuOpen ? "flex" : "hidden",
+            )}
+          >
+            <div
+              role="group"
+              aria-label={translate(locale, "Filters")}
+              className="flex flex-wrap gap-1"
+            >
+              {EventSource.map((source) => (
+                <SelectableSourceTag
+                  key={source}
+                  source={source}
+                  tags={tags}
+                  setTags={setTags}
+                />
+              ))}
+            </div>
+            <label className="flex items-center gap-2 text-xs font-medium">
+              {translate(locale, "Version")}
               <select
-                className="select select-bordered w-full pl-4"
-                value={version || versionOptions[0]}
+                className="select select-bordered w-full sm:w-40 pl-4"
+                value={version}
                 onChange={(event) => setVersion(event.target.value)}
               >
                 {versionOptions.map((candidate) => (
@@ -187,246 +107,38 @@ const EventListPage: FC<EventListPageProps> = ({
                   </option>
                 ))}
               </select>
-            </fieldset>
+            </label>
           </div>
-        </div>
-        {mobileMenuOpen && (
-          <div className="mt-2 flex flex-col gap-2 md:hidden">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-              <div className="min-w-0 flex-1">
-                <SearchBox
-                  locale={locale}
-                  search={search}
-                  setSearch={setSearch}
-                />
-              </div>
-              <fieldset className="fieldset w-full sm:w-40 shrink-0">
-                <legend className="fieldset-legend py-0 text-xs font-medium">
-                  {translate(locale, "Version")}
-                </legend>
-                <select
-                  className="select select-bordered w-full pl-4"
-                  value={version || versionOptions[0]}
-                  onChange={(event) => setVersion(event.target.value)}
-                >
-                  {versionOptions.map((candidate) => (
-                    <option key={candidate} value={candidate}>
-                      {candidate === "latest"
-                        ? translate(locale, "Latest")
-                        : candidate}
-                    </option>
-                  ))}
-                </select>
-              </fieldset>
-            </div>
-            <div className="flex flex-wrap gap-1">
-              {EventSource.map((source) => (
-                <SelectableSourceTag
-                  key={source}
-                  source={source}
-                  tags={tags}
-                  setTags={setTags}
-                />
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    </header>,
-    <main key="main" className="w-full max-w-screen-sm mx-auto py-4 px-2 grow">
-      <EventList
-        tags={tags}
-        setTags={setTags}
-        search={search}
-        locale={locale}
-        version={version}
-      />
-    </main>,
-    <footer key="footer" className="bottom-0 sticky z-20">
-      <div className="flex justify-end mr-2 mb-2">
-        <div className="flex w-full max-w-sm flex-col items-end gap-2">
-          <div className="w-full">
-            {!aiSkillHydrated ? null : !aiSkillBannerDismissed ? (
-              <div className="rounded-2xl border border-base-content/10 bg-base-100 p-4 shadow-lg">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2 font-semibold">
-                      <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-base-200">
-                        <TbRobotFace className="size-4" />
-                      </span>
-                      {translate(locale, "AiSkillTitle")}
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    className="btn btn-ghost btn-xs btn-square shrink-0"
-                    aria-label={translate(locale, "AiSkillClose")}
-                    onClick={closeAiSkillBanner}
-                  >
-                    <FiX className="size-4" />
-                  </button>
-                </div>
-                <div className="mt-3 flex flex-col gap-3">
-                  <div>
-                    <div className="mb-2 flex items-center justify-between gap-2 text-sm font-semibold">
-                      <div className="flex items-center gap-1">
-                        <span>{AI_SKILL_GH_LABEL}</span>
-                        <Link
-                          className="btn btn-ghost btn-xs"
-                          href="https://cli.github.com/manual/gh_skill_install"
-                          target="_blank"
-                          aria-label={AI_SKILL_GH_LABEL}
-                        >
-                          <FiExternalLink className="size-4" />
-                        </Link>
-                      </div>
-                      <button
-                        type="button"
-                        className="btn btn-ghost btn-xs"
-                        aria-label={
-                          copiedCommand === "gh"
-                            ? translate(locale, "AiSkillCopied")
-                            : AI_SKILL_GH_LABEL
-                        }
-                        onClick={() =>
-                          copyCommand(
-                            "gh",
-                            "gh skill install sya-ri/spigot-event-list spigot-event-search",
-                          )
-                        }
-                      >
-                        {copiedCommand === "gh" ? (
-                          <FiCheck className="size-4" />
-                        ) : (
-                          <FiCopy className="size-4" />
-                        )}
-                      </button>
-                    </div>
-                    <pre className="rounded-xl bg-base-200 p-3 text-sm overflow-x-auto">
-                      <code>
-                        gh skill install sya-ri/spigot-event-list{" "}
-                        spigot-event-search
-                      </code>
-                    </pre>
-                  </div>
-                  <div>
-                    <div className="mb-2 flex items-center justify-between gap-2 text-sm font-semibold">
-                      <div className="flex items-center gap-1">
-                        <span>{AI_SKILL_SKILLS_LABEL}</span>
-                        <Link
-                          className="btn btn-ghost btn-xs"
-                          href="https://github.com/vercel-labs/skills"
-                          target="_blank"
-                          aria-label={AI_SKILL_SKILLS_LABEL}
-                        >
-                          <FiExternalLink className="size-4" />
-                        </Link>
-                      </div>
-                      <button
-                        type="button"
-                        className="btn btn-ghost btn-xs"
-                        aria-label={
-                          copiedCommand === "skills"
-                            ? translate(locale, "AiSkillCopied")
-                            : AI_SKILL_SKILLS_LABEL
-                        }
-                        onClick={() =>
-                          copyCommand(
-                            "skills",
-                            "npx -y skills add sya-ri/spigot-event-list --skill spigot-event-search",
-                          )
-                        }
-                      >
-                        {copiedCommand === "skills" ? (
-                          <FiCheck className="size-4" />
-                        ) : (
-                          <FiCopy className="size-4" />
-                        )}
-                      </button>
-                    </div>
-                    <pre className="rounded-xl bg-base-200 p-3 text-sm overflow-x-auto">
-                      <code>
-                        npx -y skills add sya-ri/spigot-event-list --skill
-                        spigot-event-search
-                      </code>
-                    </pre>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="flex justify-end">
-                <button
-                  type="button"
-                  className="btn btn-md btn-outline btn-square"
-                  aria-label={translate(locale, "AiSkillTitle")}
-                  onClick={() => updateBannerDismissed(false)}
-                >
-                  <span className="inline-flex size-8 items-center justify-center rounded-full bg-base-200">
-                    <TbRobotFace className="size-5" />
-                  </span>
-                </button>
-              </div>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            <KoFiButton />
-          </div>
-        </div>
-      </div>
-      <div className="bg-base-300 border-base-content/10">
-        <div className="w-full max-w-screen-sm mx-auto p-1">
-          <div className="flex justify-around gap-2 items-center">
-            <div className="dropdown dropdown-hover dropdown-top">
-              <div
-                tabIndex={0}
-                role="button"
-                className="btn btn-square btn-ghost"
+          {versionsError && (
+            <div role="alert" className="flex items-center gap-2 text-sm mt-2">
+              <span>{translate(locale, "VersionsFailed")}</span>
+              <button
+                type="button"
+                className="btn btn-sm"
+                onClick={() => void retryVersions()}
               >
-                <BsTranslate className="size-5" />
-              </div>
-              <ul
-                tabIndex={0}
-                className="dropdown-content z-10 menu p-2 shadow bg-base-200 rounded-box w-64"
-              >
-                {Locale.map((l) => (
-                  <li key={l}>
-                    <a href={`/${l}`}>
-                      <div className="badge badge-outline">
-                        {l.toUpperCase()}
-                      </div>
-                      <div>
-                        {new Intl.DisplayNames(locale, {
-                          type: "language",
-                        }).of(l)}
-                      </div>
-                    </a>
-                  </li>
-                ))}
-                <li className="mt-2 pt-2 border-base-content/20">
-                  <Link
-                    href="https://github.com/sya-ri/spigot-event-list#i18n"
-                    target="_blank"
-                  >
-                    <FiPlus />
-                    {translate(locale, "AddNewLanguage")}
-                  </Link>
-                </li>
-              </ul>
+                {translate(locale, "Retry")}
+              </button>
             </div>
-            <div>
-              <Link
-                className="link-hover font-bold"
-                href="https://github.com/sya-ri/spigot-event-list"
-              >
-                © 2020-{currentYear} sya-ri
-              </Link>
-            </div>
-            <SwitchThemeButton />
-          </div>
+          )}
         </div>
-      </div>
-    </footer>,
-  ];
-};
-
-export default EventListPage;
+      </header>
+      <main
+        id="event-results"
+        tabIndex={-1}
+        className="w-full max-w-screen-sm mx-auto py-4 px-2 grow scroll-mt-40"
+      >
+        <EventList
+          key={`${locale}|${version}|${search}|${tags.join(",")}`}
+          tags={tags}
+          setTags={setTags}
+          search={search}
+          locale={locale}
+          version={version}
+          resetFilters={reset}
+        />
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/components/event-list.tsx
+++ b/src/components/event-list.tsx
@@ -24,6 +24,7 @@ type EventListProps = {
   search: string;
   locale: Locale;
   version: string;
+  resetFilters: () => void;
 };
 
 const EventList: FC<EventListProps> = ({
@@ -32,8 +33,18 @@ const EventList: FC<EventListProps> = ({
   search,
   locale,
   version,
+  resetFilters,
 }) => {
-  const { events } = useEvents(locale, version, search, tags);
+  const {
+    events,
+    total,
+    error,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    loadMore,
+    retry,
+  } = useEvents(locale, version, search, tags);
   const incompleteEvents = useMemo(
     () =>
       events?.filter(
@@ -44,19 +55,33 @@ const EventList: FC<EventListProps> = ({
       ),
     [events],
   );
-  const filteredEvents = useMemo(
-    () =>
-      events?.filter((event) => tags.includes(event.source as EventSource)) ??
-      [],
-    [events, tags],
-  );
   return (
     <div className="flex flex-col gap-4">
+      {isLoading && (
+        <p role="status" className="text-center py-8">
+          {translate(locale, "LoadingEvents")}
+        </p>
+      )}
+      {total !== undefined && (
+        <p role="status" className="text-sm text-base-content/70">
+          {translate(locale, "ShowingEvents")
+            .replace("%shown%", events.length.toLocaleString(locale))
+            .replace("%total%", total.toLocaleString(locale))}
+        </p>
+      )}
+      {!isLoading && !error && events.length === 0 && (
+        <div className="text-center py-8 space-y-3">
+          <p>{translate(locale, tags.length ? "NoEvents" : "NoSources")}</p>
+          <button type="button" className="btn btn-sm" onClick={resetFilters}>
+            {translate(locale, "ResetFilters")}
+          </button>
+        </div>
+      )}
+
       {incompleteEvents && incompleteEvents.length !== 0 && (
         <div className="bg-warning text-warning-content rounded-lg">
-          <div className="collapse collapse-arrow w-full">
-            <input type="checkbox" />
-            <div className="collapse-title">
+          <details className="collapse collapse-arrow w-full">
+            <summary className="collapse-title">
               <div className="flex items-center gap-8 w-full">
                 <FiAlertTriangle />
                 {translate(locale, "IncompleteEvents").replace(
@@ -64,7 +89,7 @@ const EventList: FC<EventListProps> = ({
                   incompleteEvents.length.toLocaleString(),
                 )}
               </div>
-            </div>
+            </summary>
             <div className="collapse-content">
               <ul className="mx-auto sm:mx-12 max-h-96 overflow-y-scroll">
                 {incompleteEvents.map((event) => (
@@ -80,10 +105,10 @@ const EventList: FC<EventListProps> = ({
                 ))}
               </ul>
             </div>
-          </div>
+          </details>
         </div>
       )}
-      {filteredEvents.map((event) => (
+      {events.map((event) => (
         <div key={`${event.source}:${event.name}:${event.link}`}>
           <div className="flex flex-wrap gap-1 justify-between">
             <Link
@@ -140,16 +165,39 @@ const EventList: FC<EventListProps> = ({
               <div>{event.deprecateDescription}</div>
             </div>
           )}
-          <div className="mt-1 break-all">{event.description}</div>
+          <div className="mt-1 break-words">{event.description}</div>
         </div>
       ))}
-      {events && (
-        <div className="text-sm text-base-content/70 text-center pt-2">
-          {translate(locale, "SearchResultsCount").replace(
-            "%size%",
-            filteredEvents.length.toLocaleString(),
-          )}
+      {error && (
+        <div role="alert" className="text-center py-4 space-y-3">
+          <p>{translate(locale, "LoadFailed")}</p>
+          <div className="flex justify-center gap-2">
+            <button
+              type="button"
+              className="btn btn-sm"
+              onClick={() => void retry()}
+            >
+              {translate(locale, "Retry")}
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm btn-ghost"
+              onClick={resetFilters}
+            >
+              {translate(locale, "ResetFilters")}
+            </button>
+          </div>
         </div>
+      )}
+      {hasMore && !error && (
+        <button
+          type="button"
+          className="btn btn-outline self-center"
+          disabled={isLoadingMore}
+          onClick={() => void loadMore()}
+        >
+          {translate(locale, isLoadingMore ? "LoadingEvents" : "LoadMore")}
+        </button>
       )}
     </div>
   );

--- a/src/components/ko-fi-button.tsx
+++ b/src/components/ko-fi-button.tsx
@@ -7,11 +7,12 @@ export const KoFiButton = () => {
   return (
     <div className="flex flex-col gap-2">
       {isOpen && (
-        <div className="bg-white rounded-xl">
+        <div id="kofi-panel" className="bg-white rounded-xl">
           <iframe
             src="https://ko-fi.com/sya_ri/?hidefeed=true&widget=true&embed=true&preview=true"
             className="border-none w-full p-1"
             height={650}
+            style={{ maxHeight: "70dvh" }}
             title="Support sya_ri"
           />
           <div className="border-t border-t-gray-300 mx-2" />
@@ -40,14 +41,19 @@ export const KoFiButton = () => {
               <img
                 src="https://ko-fi.com/img/cup-border.png"
                 className="kofiimg"
-                alt="Ko-Fi button"
+                alt=""
+                width={22}
+                height={15}
               />
               Support me on Ko-Fi
             </span>
           </a>
 
           {/* PC : iframe & link */}
-          <a
+          <button
+            type="button"
+            aria-expanded={isOpen}
+            aria-controls="kofi-panel"
             title="Support me on Ko-Fi"
             className="kofi-button rounded-full !hidden sm:!inline-block"
             onClick={() => setIsOpen(!isOpen)}
@@ -56,11 +62,13 @@ export const KoFiButton = () => {
               <img
                 src="https://ko-fi.com/img/cup-border.png"
                 className="kofiimg"
-                alt="Ko-Fi button"
+                alt=""
+                width={22}
+                height={15}
               />
               Support me on Ko-Fi
             </span>
-          </a>
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/ko-fi.css
+++ b/src/components/ko-fi.css
@@ -47,7 +47,7 @@ span.kofitext {
   color: #fff;
   text-decoration: none;
 }
-a.kofi-button {
+.kofi-button {
   box-shadow: 1px 1px 0px rgba(0, 0, 0, 0.2);
   line-height: unset;
   display: inline-block;
@@ -70,16 +70,16 @@ a.kofi-button {
   font-weight: 700;
   font-size: 14px;
 }
-a.kofi-button:visited {
+.kofi-button:visited {
   color: #fff;
   text-decoration: none;
 }
-a.kofi-button:hover {
+.kofi-button:hover {
   opacity: 0.85;
   color: #f5f5f5;
   text-decoration: none;
 }
-a.kofi-button:active {
+.kofi-button:active {
   color: #f5f5f5;
   text-decoration: none;
 }

--- a/src/components/search-box.tsx
+++ b/src/components/search-box.tsx
@@ -1,51 +1,89 @@
 "use client";
 
-import Link from "next/link";
-import { BiSearch } from "react-icons/bi";
-import { FC, useRef } from "react";
-import { usePathname, useSearchParams } from "next/navigation";
-import { omit } from "remeda";
+import { BiSearch, BiX } from "react-icons/bi";
+import { useEffect, useState } from "react";
 import { translate } from "@/i18n/translation";
-import { Locale } from "@/i18n/config";
+import type { Locale } from "@/i18n/config";
 
-export type SearchBoxProps = {
+type SearchBoxProps = {
   locale: Locale;
   search: string;
   setSearch: (value: string) => void;
 };
 
-const SearchBox: FC<SearchBoxProps> = ({ locale, search, setSearch }) => {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const ref = useRef<HTMLAnchorElement>(null);
+const SearchBox = ({ locale, search, setSearch }: SearchBoxProps) => {
+  const [draft, setDraft] = useState(search);
+  const [previousSearch, setPreviousSearch] = useState(search);
+  const [composing, setComposing] = useState(false);
+  // Restore the input together with results when navigating Back/Forward.
+  if (previousSearch !== search) {
+    setPreviousSearch(search);
+    setDraft(search);
+  }
+  useEffect(() => {
+    const restoreSearch = () => {
+      setDraft(new URLSearchParams(window.location.search).get("search") ?? "");
+      setComposing(false);
+    };
+    window.addEventListener("popstate", restoreSearch);
+    return () => window.removeEventListener("popstate", restoreSearch);
+  }, []);
+  useEffect(() => {
+    if (composing || draft === search) return;
+    const timer = window.setTimeout(() => setSearch(draft), 300);
+    return () => window.clearTimeout(timer);
+  }, [composing, draft, search, setSearch]);
+
   return (
-    <div className="join w-full">
+    <form
+      role="search"
+      className="join w-full"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!composing) setSearch(draft);
+      }}
+    >
       <input
-        type="text"
-        className="input w-full join-item px-2"
+        type="search"
+        className="input min-w-0 w-full join-item px-2"
+        aria-label={translate(locale, "SearchByNameOrDescription")}
         placeholder={translate(locale, "SearchByNameOrDescription")}
-        value={search}
-        onChange={(event) => setSearch(event.target.value)}
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onCompositionStart={() => setComposing(true)}
+        onCompositionEnd={(event) => {
+          setDraft(event.currentTarget.value);
+          setComposing(false);
+        }}
         onKeyDown={(event) => {
-          if (event.key == "Enter") {
-            ref.current?.click();
-          }
+          if (
+            event.key === "Enter" &&
+            (event.nativeEvent.isComposing || event.keyCode === 229)
+          )
+            event.preventDefault();
         }}
       />
-      <Link
-        ref={ref}
-        href={{
-          pathname,
-          query: {
-            ...omit(Object.fromEntries(searchParams.entries()), ["search"]),
-            ...(search ? { search } : {}),
-          },
-        }}
+      {draft && (
+        <button
+          type="button"
+          className="btn join-item px-2"
+          aria-label={translate(locale, "ClearSearch")}
+          onClick={() => {
+            setDraft("");
+            setSearch("");
+          }}
+        >
+          <BiX className="size-5" />
+        </button>
+      )}
+      <button
+        type="submit"
         className="btn join-item"
+        aria-label={translate(locale, "Search")}
       >
         <BiSearch className="size-4" />
-      </Link>
-    </div>
+      </button>
+    </form>
   );
 };
 

--- a/src/components/selectable-source-tag.tsx
+++ b/src/components/selectable-source-tag.tsx
@@ -1,13 +1,9 @@
 "use client";
 
-import { usePathname, useSearchParams } from "next/navigation";
-import { FC } from "react";
-import Link from "next/link";
-import EventSource from "@/types/event-source";
+import type EventSource from "@/types/event-source";
 import SourceTag from "@/components/source-tag";
 import clsx from "clsx";
-import { omit } from "remeda";
-import { addTag, joinTags, removeTag } from "@/libs/event-source-tag";
+import { addTag, removeTag } from "@/libs/event-source-tag";
 
 export type SelectableSourceTagProps = {
   source: EventSource;
@@ -15,39 +11,26 @@ export type SelectableSourceTagProps = {
   setTags: (value: EventSource[]) => void;
 };
 
-const SelectableSourceTag: FC<SelectableSourceTagProps> = ({
+const SelectableSourceTag = ({
   source,
   tags,
   setTags,
-}) => {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const selected = !tags.includes(source);
+}: SelectableSourceTagProps) => {
+  const selected = tags.includes(source);
   return (
-    <Link
-      href={{
-        pathname,
-        query: {
-          ...omit(Object.fromEntries(searchParams.entries()), ["tags"]),
-          ...(selected && tags.length + 1 == EventSource.length
-            ? {}
-            : {
-                tags: joinTags(
-                  selected ? addTag(tags, source) : removeTag(tags, source),
-                ),
-              }),
-        },
-      }}
+    <button
+      type="button"
+      aria-pressed={selected}
       onClick={() =>
-        setTags(selected ? addTag(tags, source) : removeTag(tags, source))
+        setTags(selected ? removeTag(tags, source) : addTag(tags, source))
       }
       className={clsx(
-        "cursor-pointer hover:opacity-80",
-        selected && "opacity-50 grayscale",
+        "inline-flex min-h-8 items-center rounded-lg cursor-pointer hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2",
+        !selected && "opacity-50 grayscale",
       )}
     >
       <SourceTag source={source} />
-    </Link>
+    </button>
   );
 };
 

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,0 +1,282 @@
+"use client";
+import Link from "next/link";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useSearchParams } from "next/navigation";
+import { FiPlus, FiX, FiCheck, FiCopy, FiExternalLink } from "react-icons/fi";
+import { TbRobotFace } from "react-icons/tb";
+import { BsTranslate } from "react-icons/bs";
+import { Locale } from "@/i18n/config";
+import { translate } from "@/i18n/translation";
+import useLocale from "@/i18n/use-locale";
+import SwitchThemeButton from "./switch-theme-button";
+import { KoFiButton } from "./ko-fi-button";
+
+const AI_SKILL_BANNER_DISMISSED_KEY = "spigot-event-list.ai-skill.dismissed";
+const AI_SKILL_GH_LABEL = "GitHub CLI";
+const AI_SKILL_SKILLS_LABEL = "vercel-labs/skills";
+const BANNER_EVENT = "ai-skill-banner-change";
+let memoryDismissed = false;
+const subscribeBannerDismissed = (callback: () => void) => {
+  window.addEventListener("storage", callback);
+  window.addEventListener(BANNER_EVENT, callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+    window.removeEventListener(BANNER_EVENT, callback);
+  };
+};
+const getBannerDismissedSnapshot = () => {
+  try {
+    return (
+      (window.localStorage.getItem(AI_SKILL_BANNER_DISMISSED_KEY) ??
+        String(memoryDismissed)) === "true"
+    );
+  } catch {
+    return memoryDismissed;
+  }
+};
+const updateBannerDismissed = (dismissed: boolean) => {
+  memoryDismissed = dismissed;
+  try {
+    window.localStorage.setItem(
+      AI_SKILL_BANNER_DISMISSED_KEY,
+      String(dismissed),
+    );
+  } catch {
+    /* Keep controls usable when storage is unavailable. */
+  }
+  window.dispatchEvent(new Event(BANNER_EVENT));
+};
+
+export default function SiteFooter() {
+  const locale = useLocale();
+  const searchParams = useSearchParams();
+  const currentYear = new Date().getFullYear();
+  const dismissed = useSyncExternalStore(
+    subscribeBannerDismissed,
+    getBannerDismissedSnapshot,
+    () => null,
+  );
+  const aiSkillHydrated = dismissed !== null;
+  const aiSkillBannerDismissed = dismissed;
+  const closeAiSkillBanner = () => updateBannerDismissed(true);
+  const [copiedCommand, setCopiedCommand] = useState<"gh" | "skills" | null>(
+    null,
+  );
+  const [copyError, setCopyError] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  useEffect(() => () => clearTimeout(copyTimer.current), []);
+  const copyCommand = async (kind: "gh" | "skills", value: string) => {
+    clearTimeout(copyTimer.current);
+    setCopyError(false);
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopiedCommand(kind);
+      copyTimer.current = setTimeout(() => setCopiedCommand(null), 1500);
+    } catch {
+      setCopiedCommand(null);
+      setCopyError(true);
+    }
+  };
+  return (
+    <>
+      <aside
+        aria-label={translate(locale, "AiSkillTitle")}
+        className="w-full max-w-4xl mx-auto"
+      >
+        <div className="flex justify-end mr-2 mb-2">
+          <div className="flex w-full max-w-sm flex-col items-end gap-2">
+            <div className="w-full">
+              {!aiSkillHydrated ? null : !aiSkillBannerDismissed ? (
+                <div className="rounded-2xl border border-base-content/10 bg-base-100 p-4 shadow-lg">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 font-semibold">
+                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-base-200">
+                          <TbRobotFace className="size-4" />
+                        </span>
+                        {translate(locale, "AiSkillTitle")}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-xs btn-square shrink-0"
+                      aria-label={translate(locale, "AiSkillClose")}
+                      onClick={closeAiSkillBanner}
+                    >
+                      <FiX className="size-4" />
+                    </button>
+                  </div>
+                  {copyError && (
+                    <p role="alert" className="text-error mt-2 text-sm">
+                      {translate(locale, "AiSkillCopyFailed")}
+                    </p>
+                  )}
+                  <div className="mt-3 flex flex-col gap-3">
+                    <div>
+                      <div className="mb-2 flex items-center justify-between gap-2 text-sm font-semibold">
+                        <div className="flex items-center gap-1">
+                          <span>{AI_SKILL_GH_LABEL}</span>
+                          <Link
+                            className="btn btn-ghost btn-xs"
+                            href="https://cli.github.com/manual/gh_skill_install"
+                            target="_blank"
+                            aria-label={AI_SKILL_GH_LABEL}
+                          >
+                            <FiExternalLink className="size-4" />
+                          </Link>
+                        </div>
+                        <button
+                          type="button"
+                          className="btn btn-ghost btn-xs"
+                          aria-label={
+                            copiedCommand === "gh"
+                              ? translate(locale, "AiSkillCopied")
+                              : translate(locale, "AiSkillCopy")
+                          }
+                          onClick={() =>
+                            copyCommand(
+                              "gh",
+                              "gh skill install sya-ri/spigot-event-list spigot-event-search",
+                            )
+                          }
+                        >
+                          {copiedCommand === "gh" ? (
+                            <FiCheck className="size-4" />
+                          ) : (
+                            <FiCopy className="size-4" />
+                          )}
+                        </button>
+                      </div>
+                      <pre className="rounded-xl bg-base-200 p-3 text-sm overflow-x-auto">
+                        <code>
+                          gh skill install sya-ri/spigot-event-list{" "}
+                          spigot-event-search
+                        </code>
+                      </pre>
+                    </div>
+                    <div>
+                      <div className="mb-2 flex items-center justify-between gap-2 text-sm font-semibold">
+                        <div className="flex items-center gap-1">
+                          <span>{AI_SKILL_SKILLS_LABEL}</span>
+                          <Link
+                            className="btn btn-ghost btn-xs"
+                            href="https://github.com/vercel-labs/skills"
+                            target="_blank"
+                            aria-label={AI_SKILL_SKILLS_LABEL}
+                          >
+                            <FiExternalLink className="size-4" />
+                          </Link>
+                        </div>
+                        <button
+                          type="button"
+                          className="btn btn-ghost btn-xs"
+                          aria-label={
+                            copiedCommand === "skills"
+                              ? translate(locale, "AiSkillCopied")
+                              : translate(locale, "AiSkillCopy")
+                          }
+                          onClick={() =>
+                            copyCommand(
+                              "skills",
+                              "npx -y skills add sya-ri/spigot-event-list --skill spigot-event-search",
+                            )
+                          }
+                        >
+                          {copiedCommand === "skills" ? (
+                            <FiCheck className="size-4" />
+                          ) : (
+                            <FiCopy className="size-4" />
+                          )}
+                        </button>
+                      </div>
+                      <pre className="rounded-xl bg-base-200 p-3 text-sm overflow-x-auto">
+                        <code>
+                          npx -y skills add sya-ri/spigot-event-list --skill
+                          spigot-event-search
+                        </code>
+                      </pre>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex justify-end">
+                  <button
+                    type="button"
+                    className="btn btn-md btn-outline btn-square"
+                    aria-label={translate(locale, "AiSkillTitle")}
+                    onClick={() => updateBannerDismissed(false)}
+                  >
+                    <span className="inline-flex size-8 items-center justify-center rounded-full bg-base-200">
+                      <TbRobotFace className="size-5" />
+                    </span>
+                  </button>
+                </div>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <KoFiButton />
+            </div>
+          </div>
+        </div>
+      </aside>
+      <footer className="bottom-0 sticky z-20 bg-base-300 border-base-content/10">
+        <div className="w-full max-w-screen-sm mx-auto p-1">
+          <div className="flex justify-around gap-2 items-center">
+            <div className="dropdown dropdown-hover dropdown-top">
+              <button
+                type="button"
+                aria-label={translate(locale, "Language")}
+                className="btn btn-square btn-ghost"
+              >
+                <BsTranslate className="size-5" />
+              </button>
+              <ul
+                tabIndex={0}
+                className="dropdown-content z-10 menu p-2 shadow bg-base-200 rounded-box w-64"
+              >
+                {Locale.map((l) => (
+                  <li key={l}>
+                    <a
+                      href={`/${l}${searchParams.size ? `?${searchParams}` : ""}`}
+                      lang={l}
+                      hrefLang={l}
+                    >
+                      <div className="badge badge-outline">
+                        {l.toUpperCase()}
+                      </div>
+                      <div>
+                        {new Intl.DisplayNames(locale, {
+                          type: "language",
+                        }).of(l)}
+                      </div>
+                    </a>
+                  </li>
+                ))}
+                <li className="mt-2 pt-2 border-base-content/20">
+                  <Link
+                    href="https://github.com/sya-ri/spigot-event-list#i18n"
+                    target="_blank"
+                  >
+                    <FiPlus />
+                    {translate(locale, "AddNewLanguage")}
+                  </Link>
+                </li>
+              </ul>
+            </div>
+            <div>
+              <Link
+                className="link-hover font-bold"
+                href="https://github.com/sya-ri/spigot-event-list"
+              >
+                © 2020-{currentYear} sya-ri
+              </Link>
+            </div>
+            <SwitchThemeButton />
+          </div>
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/src/components/source-tag.tsx
+++ b/src/components/source-tag.tsx
@@ -8,7 +8,7 @@ export type SourceTagProps = {
 
 const SourceTag: FC<SourceTagProps> = ({ source }) => {
   return (
-    <div
+    <span
       className={clsx(
         "rounded-lg px-1.5 text-sm my-auto font-mono",
         source == "spigot" && "bg-orange-300 text-orange-900",
@@ -19,7 +19,7 @@ const SourceTag: FC<SourceTagProps> = ({ source }) => {
       )}
     >
       {source}
-    </div>
+    </span>
   );
 };
 

--- a/src/components/switch-theme-button.tsx
+++ b/src/components/switch-theme-button.tsx
@@ -2,14 +2,18 @@
 
 import { useTheme } from "next-themes";
 import React from "react";
+import useLocale from "@/i18n/use-locale";
+import { translate } from "@/i18n/translation";
 import { BiMoon, BiSun } from "react-icons/bi";
 
 const SwitchThemeButton = () => {
+  const locale = useLocale();
   const { setTheme } = useTheme();
 
   return (
     <button
       type="button"
+      aria-label={translate(locale, "ToggleTheme")}
       className="btn btn-square btn-ghost theme-toggle"
       onClick={() => {
         const currentTheme =

--- a/src/i18n/translation.ts
+++ b/src/i18n/translation.ts
@@ -1,6 +1,24 @@
 import { Locale } from "@/i18n/config";
 
 type Message = {
+  Search: string;
+  ClearSearch: string;
+  Filters: string;
+  LoadingEvents: string;
+  LoadFailed: string;
+  VersionsFailed: string;
+  Retry: string;
+  NoEvents: string;
+  NoSources: string;
+  ResetFilters: string;
+  LoadMore: string;
+  ShowingEvents: string;
+  Language: string;
+  ToggleTheme: string;
+  AiSkillCopyFailed: string;
+  AiSkillCopy: string;
+  SkipToResults: string;
+
   SearchByNameOrDescription: string;
   AddNewLanguage: string;
   IncompleteEvents: string;
@@ -15,6 +33,24 @@ type Message = {
 
 export const messages: Record<Locale, Message> = {
   en: {
+    Search: "Search",
+    ClearSearch: "Clear search",
+    Filters: "Filters",
+    LoadingEvents: "Loading events…",
+    LoadFailed: "Unable to load events. Please try again.",
+    VersionsFailed: "Unable to load the version list.",
+    Retry: "Try again",
+    NoEvents: "No events match your search. Try different words or filters.",
+    NoSources: "Select at least one platform to see events.",
+    ResetFilters: "Reset filters",
+    LoadMore: "Load more",
+    ShowingEvents: "Showing %shown% of %total% events.",
+    Language: "Change language",
+    ToggleTheme: "Switch theme",
+    AiSkillCopyFailed: "Could not copy. Select and copy the command below.",
+    AiSkillCopy: "Copy command",
+    SkipToResults: "Skip to results",
+
     SearchByNameOrDescription: "Search by name or description",
     AddNewLanguage: "Add new language",
     IncompleteEvents: "%size% event descriptions are not written.",
@@ -27,6 +63,26 @@ export const messages: Record<Locale, Message> = {
     AiSkillCopied: "Copied",
   },
   ja: {
+    Search: "検索",
+    ClearSearch: "検索をクリア",
+    Filters: "絞り込み",
+    LoadingEvents: "イベントを読み込み中…",
+    LoadFailed: "イベントを読み込めませんでした。もう一度お試しください。",
+    VersionsFailed: "バージョン一覧を読み込めませんでした。",
+    Retry: "再試行",
+    NoEvents:
+      "一致するイベントがありません。検索語や絞り込み条件を変えてみてください。",
+    NoSources: "イベントを表示するプラットフォームを選択してください。",
+    ResetFilters: "絞り込みをリセット",
+    LoadMore: "さらに表示",
+    ShowingEvents: "%total%件中%shown%件を表示しています。",
+    Language: "言語を変更",
+    ToggleTheme: "テーマを切り替え",
+    AiSkillCopyFailed:
+      "コピーできませんでした。下のコマンドを選択してコピーしてください。",
+    AiSkillCopy: "コマンドをコピー",
+    SkipToResults: "検索結果へ移動",
+
     SearchByNameOrDescription: "イベント名・説明文で検索",
     AddNewLanguage: "翻訳を追加する",
     IncompleteEvents: "%size%個のイベント説明文が書かれていません。",

--- a/src/libs/async-cache.test.ts
+++ b/src/libs/async-cache.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createAsyncCache } from "./async-cache";
+
+test("coalesces in-flight reads and reloads only after expiry", async () => {
+  let now = 0,
+    calls = 0;
+  const cache = createAsyncCache(60, 2, () => now);
+  const load = async () => ++calls;
+  const first = cache("a", load);
+  assert.equal(cache("a", load), first);
+  assert.equal(await first, 1);
+  now = 59;
+  assert.equal(await cache("a", load), 1);
+  now = 60;
+  assert.equal(await cache("a", load), 2);
+});
+test("failed loads are evicted and retried", async () => {
+  const cache = createAsyncCache(60);
+  await assert.rejects(
+    cache("a", async () => {
+      throw new Error("temporary failure");
+    }),
+  );
+  assert.equal(await cache("a", async () => "recovered"), "recovered");
+});
+test("evicts the least recently used entry at the memory bound", async () => {
+  const cache = createAsyncCache(60_000, 2);
+  let calls = 0;
+  const load = async () => ++calls;
+  await cache("a", load);
+  await cache("b", load);
+  await cache("a", load);
+  await cache("c", load);
+  assert.equal(await cache("a", load), 1);
+  assert.equal(await cache("b", load), 4);
+});
+test("an old rejected load cannot remove its replacement", async () => {
+  const cache = createAsyncCache(60_000, 1);
+  let fail!: (error: Error) => void;
+  const old = cache(
+    "a",
+    () =>
+      new Promise<never>((_, reject) => {
+        fail = reject;
+      }),
+  );
+  await cache("b", async () => "b");
+  await cache("a", async () => "new");
+  fail(new Error("old"));
+  await assert.rejects(old);
+  assert.equal(await cache("a", async () => "incorrect reload"), "new");
+});
+test("disabled caching reads fresh data for downloader callers", async () => {
+  const cache = createAsyncCache(0);
+  let value = 1;
+  assert.equal(await cache("a", async () => value), 1);
+  value = 2;
+  assert.equal(await cache("a", async () => value), 2);
+});

--- a/src/libs/async-cache.ts
+++ b/src/libs/async-cache.ts
@@ -1,0 +1,33 @@
+// Bound both memory use and staleness; failed loads can be retried immediately.
+export const createAsyncCache = (
+  ttlMs: number,
+  maxEntries = 16,
+  now = Date.now,
+) => {
+  const entries = new Map<
+    string,
+    { expiresAt: number; value: Promise<unknown> }
+  >();
+  return <T>(key: string, load: () => Promise<T>): Promise<T> => {
+    if (ttlMs <= 0) return load();
+    const existing = entries.get(key);
+    if (existing && existing.expiresAt > now()) {
+      entries.delete(key);
+      entries.set(key, existing);
+      return existing.value as Promise<T>;
+    }
+    entries.delete(key);
+    const entry = { expiresAt: Infinity, value: Promise.resolve().then(load) };
+    entries.set(key, entry);
+    if (entries.size > maxEntries) entries.delete(entries.keys().next().value!);
+    void entry.value.then(
+      () => {
+        entry.expiresAt = now() + ttlMs;
+      },
+      () => {
+        if (entries.get(key) === entry) entries.delete(key);
+      },
+    );
+    return entry.value;
+  };
+};

--- a/src/libs/data-paths.ts
+++ b/src/libs/data-paths.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile } from "fs/promises";
 import path from "path";
+import { createAsyncCache } from "./async-cache";
 import EventType from "../../packages/downloader/src/types/event-type";
 
 const SERVER_SOURCES = ["spigot", "paper", "purpur"] as const;
@@ -102,7 +103,8 @@ export const hasCompleteServerSources = (
     (source) => source in versions,
   );
 
-export const createDataPaths = (rootPath: string) => {
+export const createDataPaths = (rootPath: string, { cacheTtlMs = 0 } = {}) => {
+  const cached = createAsyncCache(cacheTtlMs);
   const dataPath = (...parts: string[]) => path.join(rootPath, ...parts);
   const minecraftDataPath = (...parts: string[]) =>
     path.join(rootPath, "minecraft", ...parts);
@@ -216,32 +218,46 @@ export const createDataPaths = (rootPath: string) => {
 
   return {
     getLatestServerVersion,
-    getServerVersionsDesc: async () => {
-      const versions = await getServerVersionsDesc();
-      const supported: string[] = [];
-      for (const version of versions) {
-        try {
-          const versionMap = await readServerVersions(version);
-          if (hasCompleteServerSources(version, versionMap)) {
-            supported.push(version);
-          }
-        } catch {}
-      }
-      return supported;
-    },
-    readServerEvents,
+    getServerVersionsDesc: () =>
+      cached("versions", async () => {
+        const versions = await getServerVersionsDesc();
+        const supported = await Promise.all(
+          versions.map(async (version) => {
+            try {
+              return hasCompleteServerSources(
+                version,
+                await readServerVersions(version),
+              )
+                ? version
+                : null;
+            } catch {
+              return null;
+            }
+          }),
+        );
+        return supported.filter(
+          (version): version is string => version !== null,
+        );
+      }),
+    readServerEvents: (version: string) =>
+      cached(`events:${version}`, () => readServerEvents(version)),
     readServerVersions,
-    readLatestServerEvents,
-    readLatestServerVersions,
-    getLatestMinecraftVersion,
-    readProxyEvents,
+    readLatestServerEvents: () =>
+      cached("latest-events", readLatestServerEvents),
+    readLatestServerVersions: () =>
+      cached("latest-versions", readLatestServerVersions),
+    getLatestMinecraftVersion: () =>
+      cached("latest-minecraft-version", getLatestMinecraftVersion),
+    readProxyEvents: () => cached("proxy-events", readProxyEvents),
     proxyDataPath,
     minecraftVersionDataPath,
     latestDataPath,
   };
 };
 
-const appDataPaths = createDataPaths(path.join(process.cwd(), "data"));
+const appDataPaths = createDataPaths(path.join(process.cwd(), "data"), {
+  cacheTtlMs: 60_000,
+});
 
 export const getLatestServerVersion = appDataPaths.getLatestServerVersion;
 export const getServerVersionsDesc = appDataPaths.getServerVersionsDesc;

--- a/src/libs/event-data.ts
+++ b/src/libs/event-data.ts
@@ -1,0 +1,57 @@
+import {
+  getLatestMinecraftVersion,
+  getServerVersionsDesc,
+  readLatestServerEvents,
+  readProxyEvents,
+  readServerEvents,
+  resolveServerVersion,
+} from "./data-paths";
+import type EventType from "../../packages/downloader/src/types/event-type";
+import type { EventResponse } from "../types/event";
+
+export const eventDataDependencies = {
+  getLatestMinecraftVersion,
+  getServerVersionsDesc,
+  readLatestServerEvents,
+  readProxyEvents,
+  readServerEvents,
+};
+
+export type EventDataDependencies = typeof eventDataDependencies;
+
+export const readEventData = async (
+  version: string,
+  dependencies: EventDataDependencies,
+) => {
+  const [versions, latest] = await Promise.all([
+    dependencies.getServerVersionsDesc(),
+    dependencies.getLatestMinecraftVersion(),
+  ]);
+  const resolution = resolveServerVersion(version, versions, latest);
+  if (!resolution) return null;
+  if (resolution.resolvedVersion === "latest")
+    return dependencies.readLatestServerEvents();
+  const [server, proxy] = await Promise.all([
+    dependencies.readServerEvents(resolution.resolvedVersion),
+    dependencies.readProxyEvents(),
+  ]);
+  return { lang: server.lang, events: [...server.events, ...proxy.events] };
+};
+
+export const localizeEvent = (
+  event: EventType,
+  lang: string,
+): EventResponse => ({
+  name: event.name,
+  description: event.description[lang] ?? "",
+  link: event.link,
+  abstract: event.abstract,
+  source: event.source,
+  deprecate: event.deprecate,
+  deprecateDescription: event.deprecateDescription?.[lang],
+});
+
+export const compareEvents = (left: EventType, right: EventType) =>
+  left.name.localeCompare(right.name) ||
+  left.source.localeCompare(right.source) ||
+  left.link.localeCompare(right.link);

--- a/src/libs/event-search.test.ts
+++ b/src/libs/event-search.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseQuery, scoreEvent } from "./event-search";
+import type EventType from "../../packages/downloader/src/types/event-type";
+
+const event: EventType = {
+  name: "PlayerJoinEvent",
+  source: "spigot",
+  href: "join.html",
+  link: "https://example.test/join",
+  description: {
+    en: "A player joins the server",
+    ja: "プレイヤーがサーバーに参加した時に呼び出される。",
+  },
+  javadoc: "A connected player",
+  deprecateDescription: { en: "Use another API" },
+};
+test("whitespace and AND require all terms, while OR allows alternatives", () => {
+  for (const query of [
+    "player absent",
+    "player AND absent",
+    "absent OR player missing",
+  ])
+    assert.equal(scoreEvent(event, parseQuery(query)), 0);
+  for (const query of [
+    "player server",
+    "player AND server",
+    "absent OR player server",
+  ])
+    assert.ok(scoreEvent(event, parseQuery(query)) > 0);
+});
+test("quoted phrases remain contiguous and quoted operators are literal", () => {
+  assert.ok(scoreEvent(event, parseQuery('"player joins"')) > 0);
+  assert.equal(scoreEvent(event, parseQuery('"joins player"')), 0);
+  assert.equal(scoreEvent(event, parseQuery('"AND"')), 0);
+  assert.ok(scoreEvent(event, parseQuery('"a"')) > 0);
+});
+test("searches Japanese, Javadoc and deprecation text and ranks exact names first", () => {
+  for (const query of ["参加したとき", "connected", "another"])
+    assert.ok(scoreEvent(event, parseQuery(query)) > 0);
+  assert.ok(
+    scoreEvent(event, parseQuery("PlayerJoinEvent")) >
+      scoreEvent(event, parseQuery("player")),
+  );
+});
+test("empty and stop-word-only queries have no searchable clauses", () => {
+  for (const query of ["", "  ", "the and when", "AND OR"])
+    assert.deepEqual(parseQuery(query), []);
+});

--- a/src/libs/event-search.ts
+++ b/src/libs/event-search.ts
@@ -1,0 +1,177 @@
+import type EventType from "../../packages/downloader/src/types/event-type";
+
+type QueryTerm = { normalized: string };
+type QueryClause = { terms: QueryTerm[] };
+
+const normalize = (value: string | null | undefined) =>
+  (value ?? "").replace(/\s+/g, " ").trim().toLocaleLowerCase();
+
+const englishStopWords = new Set([
+  "a",
+  "an",
+  "and",
+  "at",
+  "by",
+  "for",
+  "from",
+  "in",
+  "into",
+  "is",
+  "of",
+  "on",
+  "the",
+  "to",
+  "when",
+]);
+
+const normalizeJapaneseQueryEnding = (value: string) => {
+  const suffixes = [
+    "されていたとき",
+    "されていた時",
+    "していたとき",
+    "していた時",
+    "されたとき",
+    "された時",
+    "するとき",
+    "する時",
+    "したとき",
+    "した時",
+    "である",
+    "でした",
+    "だった",
+    "されていた",
+    "していた",
+    "された",
+    "している",
+    "される",
+    "します",
+    "する",
+    "した",
+    "です",
+    "だ",
+  ];
+  for (const suffix of suffixes) {
+    if (value.endsWith(suffix) && value.length > suffix.length + 1) {
+      return value.slice(0, -suffix.length);
+    }
+  }
+  return value;
+};
+
+const normalizeQueryTerm = (value: string) => {
+  const normalized = normalize(value);
+  if (englishStopWords.has(normalized)) {
+    return "";
+  }
+  if (/^[a-z]+ies$/.test(normalized)) {
+    return `${normalized.slice(0, -3)}y`;
+  }
+  if (/^[a-z]+(?:ches|shes|xes|zes|ses)$/.test(normalized)) {
+    return normalized.slice(0, -2);
+  }
+  if (/^[a-z]{4,}s$/.test(normalized)) {
+    return normalized.slice(0, -1);
+  }
+  return normalizeJapaneseQueryEnding(normalized);
+};
+
+// Whitespace and AND require every term; OR starts an alternative clause.
+export const parseQuery = (value: string): QueryClause[] => {
+  const clauses: QueryClause[] = [];
+  let terms: QueryTerm[] = [];
+  for (const match of value.matchAll(/"([^"]+)"|'([^']+)'|[^\s]+/g)) {
+    const quoted = match[1] !== undefined || match[2] !== undefined;
+    const token = match[1] ?? match[2] ?? match[0];
+    if (!quoted && token.toUpperCase() === "OR") {
+      if (terms.length) clauses.push({ terms });
+      terms = [];
+      continue;
+    }
+    if (!quoted && token.toUpperCase() === "AND") continue;
+    const normalized = quoted ? normalize(token) : normalizeQueryTerm(token);
+    if (normalized) terms.push({ normalized });
+  }
+  if (terms.length) clauses.push({ terms });
+  return clauses;
+};
+
+const localizedValues = (value: Record<string, string> | undefined) =>
+  Object.values(value ?? {});
+
+const normalizedEvents = new WeakMap<
+  EventType,
+  {
+    name: string;
+    description: string[];
+    javadoc: string;
+    deprecateDescription: string[];
+  }
+>();
+
+const normalizedEvent = (event: EventType) => {
+  let value = normalizedEvents.get(event);
+  if (!value) {
+    value = {
+      name: normalize(event.name),
+      description: localizedValues(event.description).map(normalize),
+      javadoc: normalize(event.javadoc),
+      deprecateDescription: localizedValues(event.deprecateDescription).map(
+        normalize,
+      ),
+    };
+    normalizedEvents.set(event, value);
+  }
+  return value;
+};
+
+const matchTermScore = (
+  event: ReturnType<typeof normalizedEvent>,
+  term: QueryTerm,
+) => {
+  const lowerName = event.name;
+  if (lowerName === term.normalized) {
+    return 500;
+  }
+  if (lowerName.includes(term.normalized)) {
+    return 350;
+  }
+
+  const descriptionMatches = event.description.filter((value) =>
+    value.includes(term.normalized),
+  ).length;
+  if (descriptionMatches > 0) {
+    return 220 + descriptionMatches * 10;
+  }
+
+  if (event.javadoc.includes(term.normalized)) {
+    return 120;
+  }
+
+  const deprecateMatches = event.deprecateDescription.filter((value) =>
+    value.includes(term.normalized),
+  ).length;
+  if (deprecateMatches > 0) {
+    return 70 + deprecateMatches * 5;
+  }
+
+  return 0;
+};
+
+export const scoreEvent = (event: EventType, clauses: QueryClause[]) => {
+  const normalized = normalizedEvent(event);
+  let totalScore = 0;
+
+  for (const clause of clauses) {
+    const termScores = clause.terms.map((term) =>
+      matchTermScore(normalized, term),
+    );
+    if (termScores.some((score) => score === 0)) {
+      continue;
+    }
+    totalScore +=
+      termScores.reduce((total, score) => total + score, 0) +
+      clause.terms.length * 25;
+  }
+
+  return totalScore;
+};

--- a/src/libs/fetch-json.test.ts
+++ b/src/libs/fetch-json.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { fetchJson, HttpError } from "./fetch-json";
+
+test("returns successful JSON and surfaces HTTP failures before parsing plain text", async (context) => {
+  context.mock.method(
+    globalThis,
+    "fetch",
+    async () => new Response('{"events":[]}'),
+  );
+  assert.deepEqual(await fetchJson("/events"), { events: [] });
+  for (const status of [400, 404, 500]) {
+    context.mock.method(
+      globalThis,
+      "fetch",
+      async () => new Response("not JSON", { status }),
+    );
+    await assert.rejects(
+      fetchJson("/events"),
+      (error) => error instanceof HttpError && error.status === status,
+    );
+  }
+});
+test("propagates network errors and invalid successful JSON", async (context) => {
+  context.mock.method(globalThis, "fetch", async () => {
+    throw new TypeError("offline");
+  });
+  await assert.rejects(fetchJson("/events"), /offline/);
+  context.mock.method(globalThis, "fetch", async () => new Response("invalid"));
+  await assert.rejects(fetchJson("/events"), SyntaxError);
+});

--- a/src/libs/fetch-json.ts
+++ b/src/libs/fetch-json.ts
@@ -1,0 +1,12 @@
+export class HttpError extends Error {
+  constructor(public readonly status: number) {
+    super(`Request failed (${status})`);
+    this.name = "HttpError";
+  }
+}
+
+export const fetchJson = async <T>(url: string): Promise<T> => {
+  const response = await fetch(url);
+  if (!response.ok) throw new HttpError(response.status);
+  return response.json() as Promise<T>;
+};

--- a/src/libs/hooks/use-event-filters.ts
+++ b/src/libs/hooks/use-event-filters.ts
@@ -1,0 +1,42 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+import EventSource from "@/types/event-source";
+import { joinTags, splitTags } from "@/libs/event-source-tag";
+
+export const useEventFilters = () => {
+  const params = useSearchParams();
+  const search = params.get("search") ?? "";
+  const version = params.get("version") || "latest";
+  const tagParam = params.get("tags");
+  const tags = useMemo(() => splitTags(tagParam), [tagParam]);
+  const update = useCallback((changes: Record<string, string | null>) => {
+    const url = new URL(window.location.href);
+    for (const [key, value] of Object.entries(changes)) {
+      if (value === null) url.searchParams.delete(key);
+      else url.searchParams.set(key, value);
+    }
+    if (url.href !== window.location.href) {
+      window.history.pushState(null, "", url.pathname + url.search + url.hash);
+    }
+  }, []);
+  const setSearch = useCallback(
+    (value: string) => update({ search: value.trim() || null }),
+    [update],
+  );
+  const setTags = useCallback(
+    (value: EventSource[]) =>
+      update({
+        tags: value.length === EventSource.length ? null : joinTags(value),
+      }),
+    [update],
+  );
+  const setVersion = useCallback(
+    (value: string) => update({ version: value === "latest" ? null : value }),
+    [update],
+  );
+  const reset = useCallback(
+    () => update({ search: null, tags: null, version: null }),
+    [update],
+  );
+  return { search, version, tags, setSearch, setTags, setVersion, reset };
+};

--- a/src/libs/hooks/use-events.ts
+++ b/src/libs/hooks/use-events.ts
@@ -1,20 +1,10 @@
-import useSWRImmutable from "swr/immutable";
-import EventSource from "@/types/event-source";
-import { Locale } from "@/i18n/config";
+import useSWRInfinite from "swr/infinite";
+import type EventSource from "@/types/event-source";
+import type { Locale } from "@/i18n/config";
+import type { SearchEventsResponse } from "@/types/event";
+import { fetchJson } from "@/libs/fetch-json";
 
-type Event = {
-  name: string;
-  description: string;
-  link: string;
-  abstract?: true;
-  source: EventSource;
-  deprecate?: string;
-  deprecateDescription?: string;
-};
-
-type SearchEventsResponse = {
-  events: Event[];
-};
+const PAGE_SIZE = 50;
 
 const useEvents = (
   locale: Locale,
@@ -22,29 +12,42 @@ const useEvents = (
   search: string,
   tags: EventSource[],
 ) => {
-  const normalizedSearch = search.trim();
-  const source = tags.join(",");
-  const { data: events } = useSWRImmutable(
-    version ? ["events", locale, version, normalizedSearch, source] : null,
-    async ([, locale, version, search, source]) => {
-      if (search) {
+  const enabled = Boolean(version && tags.length);
+  const { data, error, isLoading, isValidating, size, setSize, mutate } =
+    useSWRInfinite<SearchEventsResponse, Error>(
+      (index, previous: SearchEventsResponse | null) => {
+        if (!enabled || (previous && previous.nextOffset === null)) return null;
         const params = new URLSearchParams({
-          q: search,
+          q: search.trim(),
           version,
-          source,
+          source: tags.join(","),
           lang: locale,
-          limit: "100",
+          limit: String(PAGE_SIZE),
+          offset: String(index * PAGE_SIZE),
         });
-        const response = await fetch(`/api/search/events?${params}`);
-        const data = (await response.json()) as SearchEventsResponse;
-        return data.events;
-      }
-      return fetch(
-        `/api/versions/${encodeURIComponent(version)}/events?lang=${locale}`,
-      ).then((response) => response.json() as Promise<Event[]>);
-    },
-  );
-  return { events };
+        return `/api/search/events?${params}`;
+      },
+      fetchJson<SearchEventsResponse>,
+      {
+        revalidateFirstPage: false,
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+        shouldRetryOnError: false,
+      },
+    );
+  return {
+    events: enabled ? (data?.flatMap((page) => page.events) ?? []) : [],
+    total: enabled ? data?.[0]?.total : 0,
+    error: enabled ? error : undefined,
+    isLoading: enabled && isLoading,
+    isLoadingMore:
+      enabled &&
+      !error &&
+      (isValidating || Boolean(data && size > data.length)),
+    hasMore: enabled && data?.[data.length - 1]?.nextOffset != null,
+    loadMore: () => setSize(size + 1),
+    retry: () => mutate(),
+  };
 };
 
 export default useEvents;

--- a/src/libs/hooks/use-versions.ts
+++ b/src/libs/hooks/use-versions.ts
@@ -1,4 +1,5 @@
 import useSWRImmutable from "swr/immutable";
+import { fetchJson } from "@/libs/fetch-json";
 
 type VersionsResponse = {
   latest: string;
@@ -7,15 +8,17 @@ type VersionsResponse = {
 };
 
 const useVersions = () => {
-  const { data } = useSWRImmutable("versions", () =>
-    fetch("/api/versions").then(
-      (response) => response.json() as Promise<VersionsResponse>,
-    ),
+  const { data, error, mutate } = useSWRImmutable<VersionsResponse, Error>(
+    "/api/versions",
+    fetchJson,
+    { shouldRetryOnError: false },
   );
   return {
     versions: data?.versions,
     latestVersion: data?.latest,
     latestMinecraftVersion: data?.latestMinecraftVersion,
+    error,
+    retry: () => mutate(),
   };
 };
 

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,0 +1,26 @@
+import type EventSource from "./event-source";
+
+export type EventResponse = {
+  name: string;
+  description: string;
+  link: string;
+  abstract?: true;
+  source: EventSource;
+  deprecate?: string;
+  deprecateDescription?: string;
+};
+
+export type SearchEventResponse = EventResponse & {
+  version: string;
+  javadoc?: string;
+};
+
+export type SearchEventsResponse = {
+  query: string;
+  version: string;
+  count: number;
+  total: number;
+  offset: number;
+  nextOffset: number | null;
+  events: SearchEventResponse[];
+};


### PR DESCRIPTION
Search previously sent a request on every keystroke, browser history navigation could leave the displayed filters out of sync with the URL, and search results stopped at 100 items. This change makes the URL the source of truth for filters and adds debounced search, pagination, total counts, and retry actions.

### Changes

- Debounce search requests by 300 ms and suppress requests during Japanese IME composition. Preserve filters across back/forward navigation and language changes.
- Display browse and search results in pages of 50, allowing users to reach results beyond the previous 100-item limit. Keep mobile search visible, add loading, empty, and error states, and label controls for accessibility. Move the promotional panel into the document flow so it no longer covers results.
- Share API data loading and localization. Add a 60-second cache capped at 16 entries and reuse normalized search data. Apply AND semantics to whitespace-separated terms as documented, and update the API documentation and bundled skill.
- Fetch only the required proxy metadata in parallel in the downloader. Await stream completion, propagate write errors, and support downloads without a Content-Length header.
- Use lockfile-based installs in CI and add type checks for both the web app and downloader.

### Validation

- `npm test`: all 28 tests passed.
- `npm run typecheck`: passed for both the web app and downloader.
- `npm run lint`: no errors; only the two existing Ko-Fi image warnings.
- `npm run build`: passed.
- Browser checks covered desktop and 390px mobile layouts, Japanese and English, light and dark themes, history navigation, loading 150 results, no platforms selected, recovery from an invalid version, and network failures with retries. Synthetic IME events verified that requests are suppressed during composition and sent after composition ends.
- Local handler benchmarks used the same dataset and 25 runs per query. Median search times decreased from 12–17 ms to 0.5–1.3 ms, and the initial DOM element count decreased from 5,689 to 730. These measurements exclude HTTP overhead and do not represent production Core Web Vitals.

See `docs/code-review.md` for the review scope, measurement methods, and major deferred improvements. Existing changes to event JSON files are excluded from this PR.
